### PR TITLE
Serveral fixes and added features related to Graphite graphing

### DIFF
--- a/conf_default.php.in
+++ b/conf_default.php.in
@@ -199,6 +199,9 @@ $conf['graph_engine'] = "rrdtool";
 #$conf['graph_engine'] = "graphite";
 $conf['graphite_url_base'] = "http://127.0.0.1/render";
 $conf['graphite_rrd_dir'] = "/opt/graphite/storage/rrd";
+# Don't forget a trailing "." when specifying a prefix.
+# Default is empty.
+$conf['graphite_prefix'] = "";
 
 # One of the bottlenecks is that to get individual metrics we query gmetad which
 # returns every single host and all the metrics. If you have lots of hosts and lots of 

--- a/functions.php
+++ b/functions.php
@@ -1078,13 +1078,15 @@ function build_rrdtool_args_from_json( &$rrdtool_graph, $graph_config ) {
 // Graphite graphs
 ///////////////////////////////////////////////////////////////////////////////
 function build_graphite_series( $config, $host_cluster = "" ) {
+  global $context;
   $targets = array();
   $colors = array();
   // Keep track of stacked items
   $stacked = 0;
 
   foreach( $config[ 'series' ] as $item ) {
-   
+    if ( isSet($item[ 'contexts' ]) and in_array($context, $item['contexts'])==false )
+      continue;
     if ( $item['type'] == "stack" )
       $stacked++;
 

--- a/get_context.php
+++ b/get_context.php
@@ -150,7 +150,7 @@ if(!$user['clustername'] && !$user['hostname'] && $user['controlroom']) {
 if (!$user['range'])
     $user['range'] = $conf['default_time_range'];
 
-$end = "N";
+$end = "now";
 
 # $conf['time_ranges'] defined in conf.php
 if( $user['range'] == 'job' && isSet( $user['jobrange'] ) ) {


### PR DESCRIPTION
functions.php:
-  Fix for contexts set in json templates
  get_context.php:
- Fix for Graphite graphs in graph_all_periods.php
  graph.php / conf_default.php.in:
- Added ability to specify a graphite_prefix in config so all Ganglia RRDs can be stored in a subfolder instead of the main Graphite tree
- Added fix for start and end time and min/max in Graphite graphs
- Resetting max to "" if it's 0, because Graphite doesn't really like a max of 0
- Replaced json and csv export with the Graphite version (this was done because we're using a distributed Graphite setup and the RRDs aren't stored locally on the Ganglia host)
