### PR TITLE
fix to gweb.spec.in

### DIFF
--- a/gweb.spec.in
+++ b/gweb.spec.in
@@ -1,5 +1,5 @@
 Summary: Ganglia Web Frontend
-Name: gweb
+Name: ganglia-web
 Version: @GWEB_VERSION@
 URL: http://ganglia.info
 Release: 1


### PR DESCRIPTION
I pulled down the 3.4.1 tarball and tried to build RPMS (rpmbuild -ta ganglia-web...).   RPM seemed to be confused as to whether the package was supposed to be gweb or ganglia-web and error'ed out.   Changing the name to ganglia-web fixed it.

RPMS/ganglia-web-3.4.1-1.noarch.rpm

Cheers,

-Dave

P.S. See you at Velocity this year Vladimir!  Hopefully you can make Peter and my talk.
