### PR TITLE
remember_open_metric_groups config option

### DIFF
--- a/conf_default.php.in
+++ b/conf_default.php.in
@@ -305,6 +305,10 @@ $conf['case_sensitive_hostnames'] = true;
 # groups are initially displayed or collapsed
 $conf['metric_groups_initially_collapsed'] = false;
 
+# The following property controls whether opening a metric group is
+# remembered in your sesssion
+$conf['remember_open_metric_groups'] = true;
+
 # Overlay events on graphs. Those are defined by specifying all the events
 # in events.json
 $conf['overlay_events'] = true;

--- a/host_view.php
+++ b/host_view.php
@@ -13,6 +13,7 @@ $data->assign("hostname", $hostname);
 $data->assign("graph_engine", $conf['graph_engine']);
 
 $metric_groups_initially_collapsed = isset($conf['metric_groups_initially_collapsed']) ? $conf['metric_groups_initially_collapsed'] : TRUE;
+$remember_open_metric_groups = isset($conf['remember_open_metric_groups']) ? $conf['remember_open_metric_groups'] : TRUE;
 
 $graph_args = "h=$hostname&amp;$get_metric_string&amp;st=$cluster[LOCALTIME]";
 
@@ -196,7 +197,7 @@ $open_groups = NULL;
 if (isset($_GET['metric_group']) && ($_GET['metric_group'] != "")) {
   $open_groups = explode ("_|_", $_GET['metric_group']);
 } else {
-  if (isset($_SESSION['metric_group']) && ($_SESSION['metric_group'] != ""))
+  if ($remember_open_metric_groups && isset($_SESSION['metric_group']) && ($_SESSION['metric_group'] != ""))
     $open_groups = explode ("_|_", $_SESSION['metric_group']);
 }
 


### PR DESCRIPTION
this option allows you to prevent ganglia-web from storing open metric
groups in your session and reusing them on every host page you view.
useful if you have hosts with a ton of metrics.
