### PR TITLE
Fixed monitor issue of output for UNKNOWN status in some scripts

### DIFF
--- a/nagios/check_heartbeat.php
+++ b/nagios/check_heartbeat.php
@@ -98,7 +98,7 @@ if ( $host_found == 1 ) {
   } 
   
 } else {
-   echo("UNKNOWN|Hostname info not available. Likely invalid hostname");
+   echo("UNKNOWN|" . $host. " - Hostname info not available. Likely invalid hostname");
    exit(3);
 }
 

--- a/nagios/check_metric.php
+++ b/nagios/check_metric.php
@@ -100,7 +100,7 @@ if ( $host_found == 1 ) {
   } 
   
 } else {
-   echo("UNKNOWN|" . $metric_name . " - Hostname info not available. Likely invalid hostname");
+   echo("UNKNOWN|" . $host. " - Hostname info not available. Likely invalid hostname");
    exit(3);
 }
 

--- a/nagios/check_multiple_metrics.php
+++ b/nagios/check_multiple_metrics.php
@@ -131,7 +131,7 @@ if ( $host_found == 1 ) {
   }
     
 } else {
-   echo("UNKNOWN|" . $metric_name . " - Hostname info not available. Likely invalid hostname");
+   echo("UNKNOWN|" . $host . " - Hostname info not available. Likely invalid hostname");
    exit(3);
 }
 


### PR DESCRIPTION
Some scripts were using $metric_name instead of $host for output, which would not be set if the host was not found. Change to $host so that the hostname that was looked for will be in the output.
