### PR TITLE
Fixes broken HTTPS-detection

### DIFF
--- a/tasseo.php
+++ b/tasseo.php
@@ -92,10 +92,7 @@ if ( ! isset($_GET['view_name']) ) {
 </div>
 <script>
    var ganglia_url = "<?php
-   if ( isset($_SERVER['HTTPS'] ) )
-      $proto = "https://";
-   else
-      $proto = "http://";
+   $proto = "//";
    $path_parts = pathinfo($_SERVER['SCRIPT_NAME']);
    print $proto . $_SERVER['HTTP_HOST'] .  $path_parts['dirname']; ?>";
 </script>


### PR DESCRIPTION
Fixes the broken HTTPS-detection (at least on PHP 5.3.10
$_SERVER['HTTPS'] is set but to an empty string). One could either
detect if $_SERVER['HTTPS'] is '' or 'off' or simply use the
protocol-relative URL…
