### PR TITLE
Avoid 404 error in issue #61

### DIFF
--- a/js/ganglia.js
+++ b/js/ganglia.js
@@ -21,6 +21,11 @@ $(function(){
 
   var search_field_q = $("#search-field-q");
   if (search_field_q[0]) {
+    search_field_q.keypress(function(e) {
+      if (13 == (e.keyCode ? e.keyCode : e.which)) {
+        return false;
+      }
+    });
     search_field_q.keyup(function() {
       $.cookie("ganglia-search-field-q" + window.name, $(this).val());
     });


### PR DESCRIPTION
This is for issue ganglia/ganglia-web issue #61.

The form action associated with the live-search box doesn't exist.  To
avoid a spurious 404, this change intercepts and throws away keypress
events with code 13 (enter) sent to the live-search box.

There might be a better use for the enter key in the live-search box than
simply throwing it away.  But suppressing it is better than a 404.

Thanks to maplebed and MediaWiki's landingpage.js.
