### PR TITLE
Add list action to events api

### DIFF
--- a/api/events.php
+++ b/api/events.php
@@ -97,6 +97,11 @@ switch ( $_REQUEST['action'] ) {
 
     break;
 
+  case "list":
+
+    $message = ganglia_events_get();
+    break;
+
   default:
 
     api_return_error( "No valid action specified" );


### PR DESCRIPTION
I was trying to get the full events.json for parsing on some dashboards, but I couldn't figure out a way.

This is the easiest way I could expose the entire events.json thru the API.
