### PR TITLE
Patch to move meta_designator to $conf

### DIFF
--- a/conf_default.php.in
+++ b/conf_default.php.in
@@ -99,6 +99,12 @@ $conf['metriccols'] = 2;
 #
 $conf['show_meta_snapshot'] = "yes";
 
+#
+# What you want to call the meta level:
+# Suggested values "Grid" or "Campus"
+#
+$conf['meta_designator'] = "Grid";
+
 # 
 # The default refresh frequency on pages.
 #

--- a/get_context.php
+++ b/get_context.php
@@ -2,7 +2,6 @@
 
 include_once "./functions.php";
 
-$meta_designator = "Grid";
 $cluster_designator = "Cluster Overview";
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/graph.d/metric.php
+++ b/graph.d/metric.php
@@ -11,7 +11,6 @@ function graph_metric ( &$rrdtool_graph ) {
            $jobstart,
            $load_color,
            $max,
-           $meta_designator,
            $metricname,
            $metrictitle,
            $min,
@@ -73,11 +72,11 @@ function graph_metric ( &$rrdtool_graph ) {
             break;
 
         case 'meta':
-            $rrdtool_graph['title'] = "$meta_designator ". $rrdtool_graph['title'] ."last $range";
+            $rrdtool_graph['title'] = "${conf['meta_designator']} ". $rrdtool_graph['title'] ."last $range";
             break;
 
         case 'grid':
-            $rrdtool_graph['title'] = "$meta_designator ". $rrdtool_graph['title'] ."last $range";
+            $rrdtool_graph['title'] = "${conf['meta_designator']} ". $rrdtool_graph['title'] ."last $range";
             break;
 
         case 'cluster':

--- a/graph.php
+++ b/graph.php
@@ -359,7 +359,7 @@ switch ($context)
   case "meta":
     $rrd_dir = $conf['rrds'] . "/__SummaryInfo__";
     $rrd_graphite_link = $conf['graphite_rrd_dir'] . "/__SummaryInfo__";
-    $title = "$self Grid";
+    $title = "$self ${conf['meta_designator']}";
     break;
   case "grid":
     $rrd_dir = $conf['rrds'] . "/$grid/__SummaryInfo__";
@@ -367,7 +367,7 @@ switch ($context)
     if (preg_match('/grid/i', $gridname))
         $title  = $gridname;
     else
-        $title  = "$gridname Grid";
+        $title  = "$gridname ${conf['meta_designator']}";
     break;
   case "cluster":
     $rrd_dir = $conf['rrds'] . "/$clustername/__SummaryInfo__";

--- a/header.php
+++ b/header.php
@@ -155,7 +155,7 @@ $data->assign("alt_view", $alt_view);
 $node_menu = "";
 if (($context != 'views') && ($context != 'compare_hosts')) {
   if ($parentgrid) {
-    $node_menu .= "<B><A HREF=\"$parentlink?gw=back&amp;gs=$gridstack_url&amp;$get_metric_string\">". "$parentgrid $meta_designator</A></B> ";
+    $node_menu .= "<B><A HREF=\"$parentlink?gw=back&amp;gs=$gridstack_url&amp;$get_metric_string\">". "$parentgrid ${conf['meta_designator']}</A></B> ";
     $node_menu .= "<B>&gt;</B>\n";
   }
 
@@ -163,7 +163,7 @@ if (($context != 'views') && ($context != 'compare_hosts')) {
   if ((($self != "unspecified") && !$parentgrid) ||
       $conf['always_display_grid_view']) {
     $mygrid = ($self == "unspecified") ? "" : $self;
-    $node_menu .= "<B><A HREF=\"./?$get_metric_string\">$mygrid $meta_designator</A></B> ";
+    $node_menu .= "<B><A HREF=\"./?$get_metric_string\">$mygrid ${conf['meta_designator']}</A></B> ";
     $node_menu .= "<B>&gt;</B>\n";
   }
 
@@ -191,7 +191,7 @@ if (($context != 'views') && ($context != 'compare_hosts')) {
       if ($k == $self) continue;
       if (isset($v['GRID']) and $v['GRID']) {
         $url = $v['AUTHORITY'];
-        $node_menu .="<OPTION VALUE=\"$url\">$k $meta_designator\n";
+        $node_menu .="<OPTION VALUE=\"$url\">$k ${conf['meta_designator']}\n";
       } else {
         $url = rawurlencode($k);
         $node_menu .="<OPTION VALUE=\"$url\">$k\n";

--- a/index.php
+++ b/index.php
@@ -34,11 +34,11 @@ catch (Exception $e)
 $GHOME = ".";
 
 if ($context == "meta" or $context == "control") {
-      $title = "$self $meta_designator Report";
+      $title = "$self ${conf['meta_designator']} Report";
       include_once "./header.php";
       include_once "./meta_view.php";
 } else if ($context == "tree") {
-      $title = "$self $meta_designator Tree";
+      $title = "$self ${conf['meta_designator']} Tree";
       include_once "./header.php";
       include_once "./grid_tree.php";
 } else if ($context == "cluster" or $context == "cluster-summary") {

--- a/meta_view.php
+++ b/meta_view.php
@@ -85,14 +85,14 @@ foreach ( $sorted_sources as $source => $val )
                   # Negative control room values means dont display grid summary.
                   if ($controlroom < 0) continue;
                   $num_sources = count($sorted_sources) - 1;
-                  $name = "$self $meta_designator ($num_sources sources)";
+                  $name = "$self ${conf['meta_designator']} ($num_sources sources)";
                   $graph_url = "me=$sourceurl&amp;$get_metric_string";
                   $url = "./?$get_metric_string";
                }
             else
                {
                   # Set grid context.
-                  $name = "$source $meta_designator";
+                  $name = "$source ${conf['meta_designator']}";
                   $graph_url = "G=$sourceurl&amp;$get_metric_string&amp;st=$localtime";
                   $authority = $grid[$source]['AUTHORITY'];
                   $url = "$authority?gw=fwd&amp;gs=$gridstack_url&amp;$get_metric_string";
@@ -179,7 +179,7 @@ $snap_rows = array();
 # Show load images.
 if ($conf['show_meta_snapshot']=="yes") {
    $data->assign("show_snapshot", 1);
-   $data->assign("self", "$self $meta_designator");
+   $data->assign("self", "$self ${conf['meta_designator']}");
 
    foreach ($sorted_sources as $c=>$value) {
       if ($c==$self) continue;


### PR DESCRIPTION
We are using ganglia to monitor hundreds of machines across our campus, and
would prefer to have the meta level be called 'Campus' instead of 'Grid'.

This commit takes the previous global $meta_designator and moves it into $conf[].  This also fixes the one place where 'Grid' was hard coded instead of using $meta_designator.
