### PR TITLE
Show reports only if their associated metrics are defined

### DIFF
--- a/cluster_view.php
+++ b/cluster_view.php
@@ -364,7 +364,8 @@ function get_cluster_optional_reports($conf,
                                       $clustername, 
                                       $get_metric_string,
                                       $localtime,
-                                      $data) {
+                                      $data,
+                                      $metrics) {
   $cluster_url = rawurlencode($clustername);
   $graph_args = "c=$cluster_url&amp;$get_metric_string&amp;st=$localtime";
 
@@ -415,6 +416,11 @@ function get_cluster_optional_reports($conf,
 
  foreach ($reports["included_reports"] as $index => $report_name ) {
    if (! in_array( $report_name, $reports["excluded_reports"])) {
+     # Only show metrics that actually exist for this cluster (we'll use
+     # the first host in the cluster as our sample)
+     if (isset($conf['report_to_metric'][$report_name]) &&
+         !isset($metrics[key($metrics)][$conf['report_to_metric'][$report_name]]))
+       continue;
      $optional_reports .= "<A HREF=\"./graph_all_periods.php?$graph_args&amp;g=" . $report_name . "&amp;z=large\">
     <IMG BORDER=0 style=\"padding:2px;\" $additional_cluster_img_html_args title=\"$cluster_url\" SRC=\"./graph.php?$graph_args&amp;g=" . $report_name ."&amp;z=medium\"></A>
 ";
@@ -508,7 +514,8 @@ if (! $refresh) {
 			       $clustername, 
 			       $get_metric_string,
 			       $cluster[LOCALTIME],
-			       $data);
+			       $data,
+			       $metrics);
   
   ///////////////////////////////////////////////////////////////////////////////
   // Begin Host Display Controller

--- a/conf_default.php.in
+++ b/conf_default.php.in
@@ -192,6 +192,17 @@ $conf['cluster_hide_down_hosts'] = false;
 # in the UI or default.json. Please do not use 
 #$conf['optional_graphs'] = array('packet');
 
+#
+# If you have different hosts reporting different metrics you may wish
+# to show reports for those metrics only on the hosts that have them.
+# This array maps metric names to report names- if the metric in question
+# isn't present, the report won't be shown.
+#
+#$conf['report_to_metric'] = array(
+#       "packet_report" => "pkts_in"
+#);
+#
+
 # Enable Zoom support on graphs
 $conf['zoom_support'] = true;
 

--- a/host_view.php
+++ b/host_view.php
@@ -70,6 +70,10 @@ $data->assign("additional_cluster_img_html_args", $additional_cluster_img_html_a
 
 foreach ( $reports["included_reports"] as $index => $report_name ) {
   if ( ! in_array( $report_name, $reports["excluded_reports"] ) ) {
+    # Only show metrics that actually exist for this host
+    if (isset($conf['report_to_metric'][$report_name]) && 
+	!isset($metrics[$conf['report_to_metric'][$report_name]]))
+      continue;
     $graph_anchor = "<a href=\"./graph_all_periods.php?$graph_args&amp;g=" . $report_name . "&amp;z=large&amp;c=$cluster_url\">";
 
     $addMetricBtn = "<button class=\"cupid-green\" title=\"Metric Actions - Add to View, etc\" onclick=\"metricActions('{$hostname}','{$report_name}','graph','');  return false;\">+</button>";


### PR DESCRIPTION
We have a large number of custom reports but only some of our monitored hosts
collect metrics appropriate for those reports.  The current web front end shows
an empty graph when the metric isn't present.

This commit adds a configuration array parameter ($report_to_metric) to
associate metrics with reports.  In host view, if the specified metric
isn't defined for a given host, then the report won't be shown.  In cluster
view, if the specified metric isn't defined for the first host in the
cluster, then the cluster summary report won't be shown.

(Ideally this should probably be handled by the report module itself, but since
the report module isn't called until after the page layout has already been
determined, this isn't currently feasible)
