### PR TITLE
JSON should return the TRUE value by rrdtool

### DIFF
--- a/graph.php
+++ b/graph.php
@@ -242,6 +242,15 @@ function build_graphite_series( $config, $host_cluster = "" ) {
   return $output;
 }
 
+function build_value_for_json( $value ) {
+  if ( is_numeric( $value ) )
+    $val = floatval($value);
+  else
+    $val = $value;
+
+  return $val;
+}
+
 $gweb_root = dirname(__FILE__);
 
 # RFM - Added all the isset() tests to eliminate "undefined index"
@@ -935,11 +944,11 @@ if ( $user['json_output'] ||
     if ( is_array($values["v"]) ) {
       foreach ( $values["v"] as $key => $value ) {
         $output_array[$key]["datapoints"][] = 
-	  array(floatval($value), intval($values['t']));
+	  array(build_value_for_json($value), intval($values['t']));
       }
     } else {
       $output_array[0]["datapoints"][] = 
-	array(floatval($values["v"]), intval($values['t']));
+	array(build_value_for_json($values["v"]), intval($values['t']));
     }
 
   }


### PR DESCRIPTION
Currently JSON outputs every single value as float.

So, if the metric actually has a value of "NaN" in RRD, the downstream applications/tools could get a misled value "0". "NaN" is not the same as "0", seriously.

BTW: Our Nagios plugins are very happy with this patch on monitoring a 3,000+ machines cluster.
