### PR TITLE
Incorrect cluster name determined for the host

### DIFF
--- a/ganglia.php
+++ b/ganglia.php
@@ -207,7 +207,8 @@ function start_everything ($parser, $tagname, $attrs)
 
          case "HOST":
             $hostname = $attrs['NAME'];
-	    $index_array['cluster'][$hostname][] = $cluster_name;
+            if (host_alive($attrs, $cluster_name))
+                $index_array['cluster'][$hostname][] = $cluster_name;
 
          case "METRIC":
             $metricname = rawurlencode($attrs['NAME']);


### PR DESCRIPTION
I noticed, that sometimes, gmetad leaves very old entries in its internal database:

``` xml
<CLUSTER NAME="sc-e1" LOCALTIME="1354018434" OWNER="GTL Team" LATLONG="unspecified" URL="unspecified">
<HOST NAME="gtl-host-sc-e1n14-1.xxxx.com" IP="10.36.14.17" REPORTED="1354018225" TN="22" TMAX="20" DMAX="0" LOCATION="unspecified" GMOND_STARTED="1353610234" TAGS="">
</CLUSTER>
<CLUSTER NAME="sc-aqua1" LOCALTIME="1353119973" OWNER="GTL Team" LATLONG="unspecified" URL="unspecified">
<HOST NAME="gtl-host-sc-e1n14-1.xxxx.com" IP="10.36.14.17" REPORTED="1353119951" TN="898297" TMAX="20" DMAX="0" LOCATION="unspecified" GMOND_STARTED="1341825594" TAGS="">
</CLUSTER>
```

In that case, ganglia.php  incorrectly sets cluster name for gtl-host-sc-e1n14-1.xxxx.com to the latest, expired entry.
My fix is changing that behavior. 

The reason, why the host is present in both clusters is unknown to me.  It seems to be some other bug.
