### PR TITLE
Fixes and simplications of build files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,22 @@
-# Location where gweb should be installed to
+##########################################################
+# User configurables:
+##########################################################
+# Location where gweb should be installed to (excluding conf, dwoo dirs).
 GDESTDIR = /var/www/html/ganglia
 
-APACHE_USER = apache
+# Gweb statedir (where conf dir and Dwoo templates dir are stored)
+GWEB_STATEDIR = /var/lib/ganglia-web
+
+# Gmetad rootdir (parent location of rrd folder)
+GMETAD_ROOTDIR = /var/lib/ganglia
+
+APACHE_USER =  apache
+##########################################################
 
 # Gweb version
 GWEB_MAJOR_VERSION = 3
 GWEB_MINOR_VERSION = 5
 GWEB_MICRO_VERSION = 5
-
-# Gweb statedir (where RRD files, Dwoo templates are stored)
-GWEB_STATEDIR = /var/lib
-GANGLIA_STATEDIR = $(GWEB_STATEDIR)/ganglia
-
-# Dwoo compile directory
-GWEB_DWOO = $(GANGLIA_STATEDIR)/dwoo
 
 GWEB_VERSION = $(GWEB_MAJOR_VERSION).$(GWEB_MINOR_VERSION).$(GWEB_MICRO_VERSION)
 
@@ -31,10 +34,10 @@ clean:
 	rm -rf $(TARGETS) $(DIST_DIR) $(DIST_TARBALL) rpmbuild
 
 conf_default.php:	conf_default.php.in
-	sed -e "s|@varstatedir@|$(GWEB_STATEDIR)|" conf_default.php.in > conf_default.php
+	sed -e "s|@vargmetadir@|$(GMETAD_ROOTDIR)|" -e "s|@vargwebstatedir@|$(GWEB_STATEDIR)|g" conf_default.php.in > conf_default.php
 
 ganglia-web.spec:	ganglia-web.spec.in
-	sed -e s/@GWEB_VERSION@/$(GWEB_VERSION)/ -e "s|@varstatedir@|$(GWEB_STATEDIR)|" -e "s|@varapacheuser@|$(APACHE_USER)|g" ganglia-web.spec.in > ganglia-web.spec
+	sed -e s/@GWEB_VERSION@/$(GWEB_VERSION)/ -e "s|@vargwebdir@|$(GWEB_STATEDIR)|" -e "s|@varapacheuser@|$(APACHE_USER)|g" ganglia-web.spec.in > ganglia-web.spec
 
 version.php:	version.php.in
 	sed -e s/@GWEB_VERSION@/$(GWEB_VERSION)/ version.php.in > version.php
@@ -43,12 +46,11 @@ dist-dir:	default
 	rsync --exclude "rpmbuild" --exclude "*.gz" --exclude "Makefile" --exclude "*debian*" --exclude "$(DIST_DIR)" --exclude ".git*" --exclude "*.in" --exclude "*~" --exclude "#*#" --exclude "ganglia-web.spec" -a . $(DIST_DIR)
 
 install:	dist-dir
-	mkdir -p $(DESTDIR)/$(GWEB_DWOO)/compiled && \
-	mkdir -p $(DESTDIR)/$(GWEB_DWOO)/cache && \
-	mkdir -p $(DESTDIR)/$(GANGLIA_STATEDIR) && \
-	rsync -a $(DIST_DIR)/conf/ $(DESTDIR)/$(GANGLIA_STATEDIR)/conf && \
+	mkdir -p $(DESTDIR)/$(GWEB_STATEDIR)/dwoo/compiled && \
+	mkdir -p $(DESTDIR)/$(GWEB_STATEDIR)/dwoo/cache && \
+	rsync -a $(DIST_DIR)/conf $(DESTDIR)/$(GWEB_STATEDIR) && \
 	rsync --exclude "conf" -a $(DIST_DIR)/* $(DESTDIR)/$(GDESTDIR) && \
-	chown -R $(APACHE_USER):$(APACHE_USER) $(DESTDIR)/$(GWEB_DWOO) $(DESTDIR)/$(GANGLIA_STATEDIR)/conf	
+	chown -R $(APACHE_USER):$(APACHE_USER) $(DESTDIR)/$(GWEB_STATEDIR)
 
 dist-gzip:	dist-dir
 	if [ -f $(DIST_TARBALL) ]; then \
@@ -67,5 +69,5 @@ rpm: dist-gzip ganglia-web.spec
 	rpmbuild --define '_topdir $(PWD)/rpmbuild' -bb ganglia-web.spec
 
 uninstall:
-	rm -rf $(GDESTDIR) $(GWEB_DWOO) $(GANGLIA_STATEDIR)/conf
+	rm -rf $(DESTDIR)/$(GDESTDIR)  $(DESTDIR)/$(GWEB_STATEDIR)
 

--- a/conf_default.php.in
+++ b/conf_default.php.in
@@ -10,6 +10,7 @@
 # Gmetad-webfrontend version. Used to check for updates.
 #
 $conf['gweb_root'] = dirname(__FILE__);
+$conf['gweb_confdir'] = "@vargwebstatedir@";
 
 include_once $conf['gweb_root'] . "/version.php";
 
@@ -33,20 +34,20 @@ $conf['template_name'] = "default";
 #
 
 # Where gmetad stores the rrd archives.
-$conf['gmetad_root'] = "@varstatedir@/ganglia";
+$conf['gmetad_root'] = "@vargmetadir@";
 $conf['rrds'] = "${conf['gmetad_root']}/rrds";
 
 # Where Dwoo (PHP templating engine) store compiled templates
-$conf['dwoo_compiled_dir'] = "${conf['gmetad_root']}/dwoo/compiled";
-$conf['dwoo_cache_dir'] = "${conf['gmetad_root']}/dwoo/cache";
+$conf['dwoo_compiled_dir'] = "${conf['gweb_confdir']}/dwoo/compiled";
+$conf['dwoo_cache_dir'] = "${conf['gweb_confdir']}/dwoo/cache";
 
 # Where to store web-based configuration
-$conf['views_dir'] = $conf['gmetad_root'] . '/conf';
-$conf['conf_dir'] = $conf['gmetad_root'] . '/conf';
+$conf['views_dir'] = $conf['gweb_confdir'] . '/conf';
+$conf['conf_dir'] = $conf['gweb_confdir'] . '/conf';
 
 # Where to find filter configuration files, if not set filtering
 # will be disabled
-#$conf['filter_dir'] = "${conf['gmetad_root']}/filters";
+#$conf['filter_dir'] = "${conf['gweb_confdir']}/filters";
 
 # Leave this alone if rrdtool is installed in $conf['gmetad_root'],
 # otherwise, change it if it is installed elsewhere (like /usr/bin)

--- a/ganglia-web.spec.in
+++ b/ganglia-web.spec.in
@@ -38,22 +38,22 @@ written in the PHP5 language and uses the Dwoo templating engine.
 %__mkdir -p $RPM_BUILD_ROOT/%{web_prefixdir}
 %__cp -rf * $RPM_BUILD_ROOT/%{web_prefixdir}
 %__rm -rf $RPM_BUILD_ROOT/%{web_prefixdir}/conf
-%__install -d -m 0755 $RPM_BUILD_ROOT@varstatedir@/ganglia/filters
-%__install -d -m 0755 $RPM_BUILD_ROOT@varstatedir@/ganglia/conf
-%__cp -rf conf/* $RPM_BUILD_ROOT@varstatedir@/ganglia/conf
-%__install -d -m 0755 $RPM_BUILD_ROOT@varstatedir@/ganglia/dwoo
-%__install -d -m 0755 $RPM_BUILD_ROOT@varstatedir@/ganglia/dwoo/compiled
-%__install -d -m 0755 $RPM_BUILD_ROOT@varstatedir@/ganglia/dwoo/cache
+%__install -d -m 0755 $RPM_BUILD_ROOT@vargwebdir@/filters
+%__install -d -m 0755 $RPM_BUILD_ROOT@vargwebdir@/conf
+%__cp -rf conf/* $RPM_BUILD_ROOT@vargwebdir@/conf
+%__install -d -m 0755 $RPM_BUILD_ROOT@vargwebdir@/dwoo
+%__install -d -m 0755 $RPM_BUILD_ROOT@vargwebdir@/dwoo/compiled
+%__install -d -m 0755 $RPM_BUILD_ROOT@vargwebdir@/dwoo/cache
 
 %files
 %defattr(-,root,root)
-%attr(0755,nobody,nobody)@varstatedir@/ganglia/filters
-%attr(0755,@varapacheuser@,@varapacheuser@)@varstatedir@/ganglia/conf
-%attr(0755,@varapacheuser@,@varapacheuser@)@varstatedir@/ganglia/dwoo
-%attr(0755,@varapacheuser@,@varapacheuser@)@varstatedir@/ganglia/dwoo/compiled
-%attr(0755,@varapacheuser@,@varapacheuser@)@varstatedir@/ganglia/dwoo/cache
+%attr(0755,nobody,nobody)@vargwebdir@/filters
+%attr(0755,@varapacheuser@,@varapacheuser@)@vargwebdir@/conf
+%attr(0755,@varapacheuser@,@varapacheuser@)@vargwebdir@/dwoo
+%attr(0755,@varapacheuser@,@varapacheuser@)@vargwebdir@/dwoo/compiled
+%attr(0755,@varapacheuser@,@varapacheuser@)@vargwebdir@/dwoo/cache
 %{web_prefixdir}/*
-/var/lib/ganglia/conf/*
+@vargwebdir@/conf/*
 %config(noreplace) %{web_prefixdir}/conf_default.php
 
 %clean


### PR DESCRIPTION
Hi Ganglia fans,
I made some changes to the build system for my own purposes - possibly they're good for you too...

Previously, Ganglia_statedir referred to /var/lib - not very specific to ganglia.
Also $GWEB_DWOO was defined, but not propagated to the conf template.

Now defined and propagated where appropriate:
 gmeta_rootdir (parent location of rrd folder)
 gdestdir (php files)
 gweb_statedir (parent of gweb 'conf' folder and 'dwoo' templates)

I've attempted to match up the RPM spec also, but I suspect that the
'custom_web_prefixdir' needs defining and passing from the Makefile.
Unfortunately I'm unfamiliar with RPM builds.
