### PR TITLE
Sanitize breaks quoted titles for stacked_graphs

### DIFF
--- a/stacked.php
+++ b/stacked.php
@@ -9,6 +9,9 @@ $conf['gweb_root'] = dirname(__FILE__);
 include_once $conf['gweb_root'] . "/eval_conf.php";
 include_once $conf['gweb_root'] . "/functions.php";
 
+clean($_REQUEST);
+clean($_GET);
+
 $clustername = $_REQUEST['c'];
 $metricname = $_REQUEST['m'];
 $range = $_REQUEST['r'];
@@ -169,6 +172,15 @@ function get_col($value){
     list($r,$g,$b) = HSV_TO_RGB($value, 1, 0.9);
 
     return sprintf('%02X%02X%02X',$r,$g,$b);
+}
+
+function clean($elem){
+    if(!is_array($elem))
+        $elem = sanitize($elem);
+    else
+        foreach ($elem as $key => $value)
+            $elem[$key] = clean($value);
+    return $elem;
 }
 
 ?>

--- a/stacked.php
+++ b/stacked.php
@@ -115,7 +115,6 @@ foreach($hosts as $index => $host) {
     $c++;
 }
 
-$command = sanitize($command);
 $command .= $total_cmd . $mean_cmd;
 $command .= " COMMENT:'\\j'";
 $command .= " GPRINT:'total':AVERAGE:'Avg Total\: %5.2lf'";


### PR DESCRIPTION
Fixes issues with the stacked graphs title command removing quotes:

The following would fail

``` bash
" --title " . escapeshellarg(
    "$clustername aggregated $metricname last $range");
```

We'd expect something like `--title 'production aggregated load_one last hour'`, however we see `--title production aggregated load_one last hour`.

This also removes other quotes that are required for associated commands for rrdtool's cli.

The culprit is this santize function, which I'm sure has some valid reasons to be used, but is perhaps not the best solution.
