### PR TITLE
graph.php: Delegate rrdtool execution to bash script instead of running command directly.

### DIFF
--- a/graph.php
+++ b/graph.php
@@ -924,11 +924,21 @@ if ( $user['json_output'] ||
     . $rrd_options . " " . $rrdtool_graph_args;
 
   // Read in the XML
-  $fp = popen($command,"r"); 
   $string = "";
-  while (!feof($fp)) { 
-    $buffer = fgets($fp, 4096);
-    $string .= $buffer;
+  if (strlen($command) < 100000) {
+    $fp = popen($command,"r"); 
+    while (!feof($fp)) { 
+      $buffer = fgets($fp, 4096);
+      $string .= $buffer;
+    }
+  } else {
+    $tempfile = tempnam("/tmp", "ganglia-graph-json");
+    file_put_contents($tempfile, $command);
+    $tempstring = exec("/bin/bash $tempfile", $tempout);
+    foreach( $tempout as $line ) {
+      $string .= $line;
+    }
+    unlink($tempfile);
   }
 
   // Parse it


### PR DESCRIPTION
Calling ganglia-web services with JSON set as output might result in empty response if executed command line is too long. Some calls to rrdtool are wrapped in a bash script to avoid exceeding maximum command line length, this one was left out. Wrapping is done only when it is necessary, when a command in at least 100000 chars long.
