### PR TITLE
Fix bug with event api deletion

### DIFF
--- a/lib/Events/Driver_Json.php
+++ b/lib/Events/Driver_Json.php
@@ -80,7 +80,8 @@ function ganglia_event_delete( $event_id ) {
 			$conf['overlay_events_file'] . 
 			". Please check permissions." );
     } else {
-      $message = array( "status" => "ok", "event_id" => $event_id );
+        $message = array( "status" => "ok", "message" => "Event ID " . $event_id . " deleted successfully" );
+        return $message;
     }
   }
   api_return_error( "Event ID ". $event_id . " not found" );


### PR DESCRIPTION
Issue: When you delete an event using the event api, it was incorrectly
returning "Event ID ${eventid} not found" when the event was found and deleted.
It was returning the same message if the event was not found.

Delete now returns properly on file write error, event not found and successful
deletion.
