### PR TITLE
Make size of optional graphs configurable

### DIFF
--- a/cluster_view.php
+++ b/cluster_view.php
@@ -416,7 +416,7 @@ function get_cluster_optional_reports($conf,
  foreach ($reports["included_reports"] as $index => $report_name ) {
    if (! in_array( $report_name, $reports["excluded_reports"])) {
      $optional_reports .= "<A HREF=\"./graph_all_periods.php?$graph_args&amp;g=" . $report_name . "&amp;z=large\">
-    <IMG BORDER=0 style=\"padding:2px;\" $additional_cluster_img_html_args title=\"$cluster_url\" SRC=\"./graph.php?$graph_args&amp;g=" . $report_name ."&amp;z=medium\"></A>
+    <IMG BORDER=0 style=\"padding:2px;\" $additional_cluster_img_html_args title=\"$cluster_url\" SRC=\"./graph.php?$graph_args&amp;g=" . $report_name ."&amp;z=" . $conf['default_optional_graph_size'] . "\"></A>
 ";
    }
  }

--- a/conf_default.php.in
+++ b/conf_default.php.in
@@ -310,6 +310,10 @@ $conf['graph_sizes_keys'] = array_keys( $conf['graph_sizes'] );
 # the view .json file.
 $conf['default_view_graph_size'] = 'medium';
 
+# sets a default graph size for optional graphs separate from the regular
+# default graph size.
+$conf['default_optional_graph_size'] = 'medium';
+
 # The API can serve up graphs, but the URLs should be fully qualified.
 # The default value is a hack to serve up the called hostname when
 # possible. It is best to define this manually.

--- a/host_view.php
+++ b/host_view.php
@@ -127,7 +127,7 @@ function getOptionalReports($hostname,
 	$showEventBtn = '<input title="Hide/Show Events" type="checkbox" id="' . $SHOW_EVENTS_BASE_ID . $report_name . '" onclick="showEvents(\'' . $graphId . '\', this.checked)"/><label class="show_event_text" for="' . $SHOW_EVENTS_BASE_ID . $report_name . '">Hide/Show Events</label>';
 	if(checkAccess(GangliaAcl::ALL_VIEWS, GangliaAcl::EDIT, $conf))
 	  $optional_reports .= $addMetricBtn . '&nbsp;';
-	$optional_reports .= $csvBtn . '&nbsp;' . $jsonBtn . '&nbsp;' .$inspectBtn . '&nbsp;' . $showEventBtn . "<br />" . $graph_anchor . "<img id=\"" . $graphId . "\" $additional_cluster_img_html_args border=\"0\" title=\"$cluster_url\" SRC=\"./graph.php?$graph_args&amp;g=" . $report_name ."&amp;z=medium&amp;c=$cluster_url\" style=\"margin-top:5px;\" /></a></div>";
+	$optional_reports .= $csvBtn . '&nbsp;' . $jsonBtn . '&nbsp;' .$inspectBtn . '&nbsp;' . $showEventBtn . "<br />" . $graph_anchor . "<img id=\"" . $graphId . "\" $additional_cluster_img_html_args border=\"0\" title=\"$cluster_url\" SRC=\"./graph.php?$graph_args&amp;g=" . $report_name ."&amp;z=" . $conf['default_optional_graph_size'] . "&amp;c=$cluster_url\" style=\"margin-top:5px;\" /></a></div>";
       }
     }
   } // foreach


### PR DESCRIPTION
We'd like to have the optional graphs in the cluster and host view
bigger.  In the past, I just modified cluster_view.php and
host_view.php.  To avoid that modification and forward porting of my
changes I've added a new configuration option.
