### PR TITLE
Reports only in cluster view and not host view

### DIFF
--- a/conf_default.php.in
+++ b/conf_default.php.in
@@ -389,6 +389,9 @@ $conf['show_stacked_graphs'] = 1;
 # single cluster has been defined.
 $conf['always_display_grid_view'] = true;
 
+# In the host view, should we include/exclude optional cluster graphs?
+$conf['optional_cluster_graphs_for_host_view'] = true;
+
 # Color for the timeshift line
 $conf['timeshift_line_color'] = "#FFD17F";
 

--- a/host_view.php
+++ b/host_view.php
@@ -62,10 +62,13 @@ function getOptionalReports($hostname,
 
   $cluster_override_reports = array("included_reports" => array(),
 				    "excluded_reports" => array());
-  if (is_file($cluster_file)) {
-    $cluster_override_reports = array_merge(
-      $cluster_override_reports,
-      json_decode(file_get_contents($cluster_file), TRUE));
+
+  if ($conf['optional_cluster_graphs_for_host_view']) {
+    if (is_file($cluster_file)) {
+      $cluster_override_reports = array_merge(
+        $cluster_override_reports,
+        json_decode(file_get_contents($cluster_file), TRUE));
+    } 
   } 
 
   $host_file = $conf['conf_dir'] . "/host_" . $hostname . ".json";


### PR DESCRIPTION
When collection the optional graphs for a host, the logic is as follows:
- get default_reports from default.json
- get cluster_override_reports from cluster_<name>.json
- if host_<name>.json exists, take these as overwrite_reports, otherwise
  use the cluster_override
- at last merge all three reports

So, even if there is a host_<name>.json, we always merge in the
cluster reports.

For the Power systems we use, we have graphs that are only useful in
the cluster view. These cluster graphs should not be displayed for the
hosts. Since the current behavior might be useful for other people
make it configurable with $conf['optional_cluster_graphs_for_host_view']
