### PR TITLE
cache robustness

### DIFF
--- a/lib/cache.php
+++ b/lib/cache.php
@@ -24,10 +24,10 @@
             echo("DEBUG: Querying GMond for new data\n");
         }
         // Set up for cluster summary
-        $context = "index_array";
         include_once $conf['gweb_root'] . "/functions.php";
         include_once $conf['gweb_root'] . "/ganglia.php";
-        include_once $conf['gweb_root'] . "/get_ganglia.php";
+        $GLOBALS['context'] = "index_array";
+        include $conf['gweb_root'] . "/get_ganglia.php";
 
         // only save if the result looks good
         if (count($index_array) > 0) {


### PR DESCRIPTION
Previously:
- `rm cache`
- go to view

Would result in no metrics being found (because cluster lookup would fail).  It did work if you went to the Aggregate page first, or otherwise had gotten the cache filled with the right data.
