### PR TITLE
nagios_cache_file can be written after reducing redundant mem footprint ...

### DIFF
--- a/api/metrics_autocomplete.php
+++ b/api/metrics_autocomplete.php
@@ -41,9 +41,9 @@ if ( ! is_array( $metrics ) ) {
     	$new_metrics[$mhost][$name]['UNITS'] = $metrics[$mhost][$name]['UNITS'];
     }
   }
-  file_put_contents($conf['nagios_cache_file'], serialize($new_metrics));
   unset($metrics);
-  $metrics = $new_metrics;
+  file_put_contents($conf['nagios_cache_file'], serialize($new_metrics));
+  $metrics = $new_metrics;  
   unset($new_metrics);
 }
 


### PR DESCRIPTION
while writing nagios metric cache file, these lines often appear in the httpd logs even after increasing the memory the memory limit to the tunes of a GB. Admittedly, nagios_ganglia.cache is of just 37M file content in comparision.

 Allowed memory size of 1073741824 bytes exhausted (tried to allocate 34882418 bytes) in /var/www/html/ganglia/api/metrics_autocomplete.php on line 44,

(btw, I think there should be a memcached driver support for having nagios metric cache even in memcached, that would be too good to.)
