### PR TITLE
Define and use my_passthru() to avoid incomplete images shown in browsers

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1384,4 +1384,18 @@ function heuristic_urldecode($blob) {
   }
   return $blob;
 }
+
+// alternative passthru() implementation to avoid incomplete images shown in
+// browsers.
+function my_passthru($command) {
+  $tf = tempnam('/tmp', 'ganglia-graph.');
+  $ret = exec("$command > $tf");
+  $size = filesize($tf);
+  header("Content-Length: $size");
+  $fp = fopen($tf, 'rb');
+  fpassthru($fp);
+  fclose($fp);
+  unlink($tf);
+}
+
 ?>

--- a/graph.php
+++ b/graph.php
@@ -1408,11 +1408,11 @@ if($command || $graphite_url) {
       case "flot":
           case "rrdtool":
             if (strlen($command) < 100000) {
-              passthru($command);
+              my_passthru($command);
             } else {
               $tf = tempnam("/tmp", "ganglia-graph");
               file_put_contents($tf, $command);
-              passthru("/bin/bash $tf");
+              my_passthru("/bin/bash $tf");
               unlink($tf);
             }
             break;

--- a/stacked.php
+++ b/stacked.php
@@ -138,7 +138,7 @@ if (isset($_GET['debug']))
 else
     {
     header ("Content-type: image/png");
-    passthru($command);
+    my_passthru($command);
     }
 
 function HSV_TO_RGB ($H, $S, $V){


### PR DESCRIPTION
I got incomplete graphs over internet connections without this modification.
Here is an example screenshot for 
http://ganglia.wmflabs.org/latest/?c=mwreview&h=unicorn&m=load_one&r=hour&s=by%20name&hc=4&mc=2
(Note: this is not my site).
![ganglia_incomplete_graph_images](https://f.cloud.github.com/assets/19299/979613/fff32fdc-0719-11e3-915b-5d5f3fdd9dc8.png)
I got the same problem for my private site in the AWS Tokyo region.

I don't have any incomplete graphs in my setup of ganglia accessed via LAN connections.

It seems a problem of Transfer-Encoding: chunked which is used by php passthru().
I modified that first run the rrdtool command to write ouput to a temporary file and then
set a Content-Length: response header.

With this modification, I don't have any incomplete graphs on my private site at the AWS Tokyo region.
