### PR TITLE
Make command string shorter for exec

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1388,7 +1388,7 @@ function my_passthru($command) {
   $cmdfp = fopen($cmdf, 'wb');
   fwrite($cmdfp, $command);
   fclose($cmdfp);
-  $cmd = "/bin/bash $cmdf";
+  $cmd = "/bin/sh $cmdf";
   $tf = tempnam('/tmp', 'ganglia-graph.');
   $ret = exec("$cmd > $tf");
   unlink($cmdf);


### PR DESCRIPTION
If you have really many hosts and stack graph is not generated with no reason,
too long command could be one reason.

When we have too many hosts, given command string to (my_)passthru
becomes so long(in my case, >2MBs) that 'exec' function cannot handle it properly.
Saving command in the file seems a little bit inefficient but works correctly even if
you have many(>1000) hosts, especially for generating stacked graph.
