### PR TITLE
Views fixed: missing $index_array initialization

### DIFF
--- a/ganglia.php
+++ b/ganglia.php
@@ -356,6 +356,7 @@ function Gmetad ()
             $request = "/$clustername";
              break;
          case "index_array":
+         case "views":
             xml_set_element_handler($parser, "start_everything", "end_all");
             $request = "/";
              break;


### PR DESCRIPTION
Now views need $index_array to get cluster name by hostname, however,
initialization code was missing in the views context. It happened when
moving views from host context into views context.
