### PR TITLE
Fix for issue 212 - Failure to create cluster heatmap

### DIFF
--- a/cluster_view.php
+++ b/cluster_view.php
@@ -546,8 +546,12 @@ function get_load_heatmap($hosts_up, $host_regex, $metrics, $data) {
       $col_index++;
   }
 
-  if ($col_index != 0)
+  if ($col_index != 0) {
+    for ($i = 0; $i < ($num_cols * $num_cols - $num_hosts); $i++) {
+      $heatmap .= ",{host:\"unused\",load:0}";
+    }
     $heatmap .= ']';
+  }
   $heatmap .= ']';
 
   $data->assign("heatmap_data", $heatmap);


### PR DESCRIPTION
I was able to reproduce the issue by simulating a cluster with a number of hosts that does not have an exact integer square root, and tested the fix in the same way. Sorry for any incovenience.

Peter
