### PR TITLE
Apply host_regex to down_hosts

### DIFF
--- a/cluster_view.php
+++ b/cluster_view.php
@@ -187,6 +187,10 @@ function get_host_metric_graphs($showhosts,
   } // foreach hosts_up
          
   foreach ($hosts_down as $host => $val) {
+    // If host_regex is defined
+    if (isset($user['host_regex']) && 
+	! preg_match("/" .$user['host_regex'] . "/", $host))
+      continue;
     $down_hosts[$host] = -1.0;
   }
 


### PR DESCRIPTION
If host_regex is specified, hosts on cluster view include down_hosts that don't match host_regex. It is better to change algorithm to apply host_regex to down_hosts.
