### PR TITLE
Avoid filter_input for compatibility with PHP < 5.2.

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -3,7 +3,7 @@ $tpl = new Dwoo_Template_File( template("footer.tpl") );
 $data = new Dwoo_Data(); 
 $data->assign("webfrontend_version",$version["webfrontend"]);
 
-if (isset($_GET["hide-hf"]) && filter_input(INPUT_GET, "hide-hf", FILTER_VALIDATE_BOOLEAN, array("flags" => FILTER_NULL_ON_FAILURE))) {
+if (isset($_GET["hide-hf"]) && $_GET["hide-hf"] == "true") {
   $data->assign("hide_footer", true);
 }
 

--- a/header.php
+++ b/header.php
@@ -286,7 +286,7 @@ if(count($gridstack) > 1) {
 $tpl = new Dwoo_Template_File( template("$header.tpl") );
 $data = new Dwoo_Data();
 
-if (isset($_GET["hide-hf"]) && filter_input(INPUT_GET, "hide-hf", FILTER_VALIDATE_BOOLEAN, array("flags" => FILTER_NULL_ON_FAILURE))) {
+if (isset($_GET["hide-hf"]) && $_GET["hide-hf"] == "true") {
   $data->assign("hide_header", true);
 }
 


### PR DESCRIPTION
This change avoids filter_input(), for systems with older PHP versions like RHEL/Centos 5.X.
