### PR TITLE
Fix physical view in-rack machine ordering

### DIFF
--- a/physical_view.php
+++ b/physical_view.php
@@ -64,8 +64,8 @@ function physical_racks()
          # Try to find the node's location in the cluster.
          list($rack, $rank, $plane) = findlocation($v);
 
-         if ($rack>=0 and $rank>=0 and $plane>=0) {
-            $racks[$rack][]=$v['NAME'];
+         if ($rack>=0 and $rank>=0 and $plane>=0 and !array_key_exists($rank, $racks[$rack])) {
+            $racks[$rack][$rank]=$v['NAME'];
             continue;
          }
          else {
@@ -80,8 +80,8 @@ function physical_racks()
    if (is_array($hosts_down)) {
       foreach ($hosts_down as $host=>$v) {
          list($rack, $rank, $plane) = findlocation($v);
-         if ($rack>=0 and $rank>=0 and $plane>=0) {
-            $racks[$rack][]=$v['NAME'];
+         if ($rack>=0 and $rank>=0 and $plane>=0 and !array_key_exists($rank, $racks[$rack])) {
+            $racks[$rack][$rank]=$v['NAME'];
             continue;
          }
          else {


### PR DESCRIPTION
The physical view was not ordering machines in a rack by their rank.  Revert to the behavior of the original Ganglia web interface where this was done.
