### PR TITLE
Changed "Show Hosts Scaled" button indexes

### DIFF
--- a/cluster_view.php
+++ b/cluster_view.php
@@ -628,8 +628,8 @@ if (! $refresh) {
   $data->assign("sort", $sort);
   $data->assign("range", $range);
   
-  $showhosts_levels = array(2 => array('checked'=>'', 'name'=>'Auto'),
-			    1 => array('checked'=>'', 'name'=>'Same'),
+  $showhosts_levels = array(1 => array('checked'=>'', 'name'=>'Auto'),
+			    2 => array('checked'=>'', 'name'=>'Same'),
 			    0 => array('checked'=>'', 'name'=>'None'),
 			    );
   $showhosts_levels[$showhosts]['checked'] = 'checked';


### PR DESCRIPTION
In the Cluster view, the behavior of Auto/Same appear to be reversed.  This change, unless we're completely misunderstanding it, results in "Auto" being selected by default and all the server metrics show as we expect.

![ganglia___goapp_cluster_report](https://f.cloud.github.com/assets/406732/2329164/2af9161c-a411-11e3-9859-4d9f785df6e8.png)

![ganglia___goapp_cluster_report](https://f.cloud.github.com/assets/406732/2329161/20d04174-a411-11e3-91c9-713b96467e3b.png)
