### PR TITLE
Added mem_free to graph.d/mem_report.php graph...

### DIFF
--- a/conf_default.php.in
+++ b/conf_default.php.in
@@ -136,7 +136,7 @@ $conf['mem_used_color'] = "5555cc";
 $conf['mem_shared_color'] = "0000aa";
 $conf['mem_cached_color'] = "33cc33";
 $conf['mem_buffered_color'] = "99ff33";
-$conf['mem_free_color'] = "00ff00";
+$conf['mem_free_color'] = "f0ffc0";
 $conf['mem_swapped_color'] = "9900CC";
 
 #

--- a/graph.d/mem_report.php
+++ b/graph.d/mem_report.php
@@ -129,6 +129,22 @@ function graph_mem_report ( &$rrdtool_graph ) {
         }
     }
 
+    if (file_exists("$rrd_dir/mem_free.rrd")) {
+        $series .= "STACK:'bmem_free'#${conf['mem_free_color']}:'Free${rmspace}' ";
+
+        if ( $conf['graphreport_stats'] ) {
+            $series .= "CDEF:free_pos=bmem_free,0,INF,LIMIT "
+                    . "VDEF:free_last=free_pos,LAST "
+                    . "VDEF:free_min=free_pos,MINIMUM " 
+                    . "VDEF:free_avg=free_pos,AVERAGE " 
+                    . "VDEF:free_max=free_pos,MAXIMUM " 
+                    . "GPRINT:'free_last':' ${space1}Now\:%6.1lf%s' "
+                    . "GPRINT:'free_min':'${space1}Min\:%6.1lf%s${eol1}' "
+                    . "GPRINT:'free_avg':'${space2}Avg\:%6.1lf%s' "
+                    . "GPRINT:'free_max':'${space1}Max\:%6.1lf%s\\l' ";
+        }
+    }
+
     if (file_exists("$rrd_dir/swap_total.rrd")) {
         $series .= "DEF:'swap_total'='${rrd_dir}/swap_total.rrd':'sum':AVERAGE "
                 . "DEF:'swap_free'='${rrd_dir}/swap_free.rrd':'sum':AVERAGE "


### PR DESCRIPTION
... Was present in ganglia web 1. Also ported RGB color definition from there.

Reason:
Displaying memory graph for linux hosts works as expected, but metrics from windows
Host sFlow agents displayed swap usage where free memory should be displayed.
Therefore it presented itself as when machine has all of it's memory and lots
of swap space occupied, when that was clearly not the case.

This change adds it back to graph stack and also displays now/min/max/avg
values in the legend.
