### PR TITLE
Provide the option to remove unnecessary XML data

### DIFF
--- a/conf_default.php.in
+++ b/conf_default.php.in
@@ -433,4 +433,9 @@ $conf['display_views_using_tree'] = false;
 # when the tree is first created in a browser session. Path entries are 
 # separated using "--"
 #$conf['view_tree_nodes_initially_open'] = array();
+
+# Gmetad will send back <EXTRA_DATA> information that is not utilized
+# in many code paths. This will pre-emptively strip out the tags in 
+# those code paths to save time during XML parsing.
+$conf['strip_extra'] = true;
 ?>

--- a/ganglia.php
+++ b/ganglia.php
@@ -344,6 +344,7 @@ function Gmetad ()
    if ( $context == "compare_hosts" or $context == "views" or $context == "decompose_graph") 
       return TRUE;
    $parser = xml_parser_create();
+   $strip_extra = $conf['strip_extra'];
    switch ($context)
       {
          case "meta":
@@ -357,12 +358,12 @@ function Gmetad ()
          case "cluster":
             xml_set_element_handler($parser, "start_cluster", "end_all");
             $request = "/$clustername";
-             break;
+            break;
          case "index_array":
          case "views":
             xml_set_element_handler($parser, "start_everything", "end_all");
             $request = "/";
-             break;
+            break;
          case "cluster-summary":
             xml_set_element_handler($parser, "start_cluster_summary", "end_all");
             $request = "/$clustername?filter=summary";
@@ -371,6 +372,7 @@ function Gmetad ()
          case "host":
             xml_set_element_handler($parser, "start_host", "end_all");
             $request = "/$clustername/$hostname";
+            $strip_extra = false;
             break;
       }
 
@@ -404,6 +406,7 @@ function Gmetad ()
    while(!feof($fp))
       {
          $data = fread($fp, 16384);
+         if($strip_extra) $data = preg_replace('/<EXTRA_DATA>.*?<\/EXTRA_DATA>/s', '', $data);
          if (!xml_parse($parser, $data, feof($fp)))
             {
                $error = sprintf("XML error: %s at %d",


### PR DESCRIPTION
The EXTRA_DATA and EXTRA_ELEMENT data returned by Ganglia is unused in many code paths, so by stripping it we can see XML parsing performance gains of about 50% for large data sets.

In production, gmetad was returning 26MB of XML data for the everything path.  By filtering this subset of data out, it took parsing time from an average of 2.1s to 1.1s, a nearly 50% improvement.

By looking at the start_\* functions, we can see if they use the EXTRA_DATA information at all.  Since most of them don't, we can safely strip out the information.
