### PR TITLE
No need to fold since gmetad returns upper-case

### DIFF
--- a/ganglia.php
+++ b/ganglia.php
@@ -401,6 +401,9 @@ function Gmetad ()
 
    $start = gettimeofday();
 
+   xml_parser_set_option($parser, XML_OPTION_SKIP_WHITE, 1);
+   xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, 0);
+
    while(!feof($fp))
       {
          $data = fread($fp, 16384);


### PR DESCRIPTION
http://php.net/manual/en/function.xml-parser-set-option.php
http://php.net/manual/en/xml.case-folding.php

Gmetad returns everything as upper-case.  We shouldn't waste CPU inspecting this.

We also can skip white space.
