### PR TITLE
Use the new path for functions.php

### DIFF
--- a/api/search.php
+++ b/api/search.php
@@ -14,7 +14,7 @@ $conf['gweb_root'] = dirname(dirname(__FILE__));
 
 include_once $conf['gweb_root'] . "/eval_conf.php";
 include_once $conf['gweb_root'] . "/lib/common_api.php";
-include_once $conf['gweb_root'] . "/lib/functions.php";
+include_once $conf['gweb_root'] . "/functions.php";
 
 ganglia_cache_metrics();
 


### PR DESCRIPTION
`/lib/functions.php` was moved to `/functions.php` for quite a while.
This PR uses the new path for `/api/search.php` to include it.