### PR TITLE
Case-Sensitivity fix for hostnames and cluster_view

### DIFF
--- a/cluster_view.php
+++ b/cluster_view.php
@@ -257,7 +257,7 @@ function get_host_metric_graphs($showhosts,
       // If we're hiding DOWN hosts, we skip to next iteration of the loop.
       continue;
     }
-    $host_url = rawurlencode($host);
+    $host_url = ($case_sensitive_hostnames) ? rawurlencode($host) : strtolower(rawurlencode($host));
     
     $host_link="\"?c=$cluster_url&amp;h=$host_url&amp;$get_metric_string\"";
     $textval = "";


### PR DESCRIPTION
If case_sensitive_hostnames is set to false, lowercase the hostname for $host_url or else the graphs will not draw.