### PR TITLE
Allow adding default graphs on host view only

### DIFF
--- a/host_view.php
+++ b/host_view.php
@@ -68,6 +68,12 @@ function getOptionalReports($hostname,
       json_decode(file_get_contents($conf['conf_dir'] . "/default.json"), 
 		  TRUE));
   }
+  if ( is_file($conf['conf_dir'] . "/default_host.json") ) {
+    $default_reports = array_merge(
+      $default_reports,
+      json_decode(file_get_contents($conf['conf_dir'] . "/default_host.json"),
+		  TRUE));
+  }
 
   $cluster_file = $conf['conf_dir'] .
     "/cluster_" .


### PR DESCRIPTION
Useful for showing for instance the new disk_report, that is more interesting on a host-by-host basis.