### PR TITLE
Remove invalid rrdtool option (-t).

### DIFF
--- a/graph.php
+++ b/graph.php
@@ -1126,7 +1126,7 @@ function output_data_to_external_format($rrdtool_graph_series,
     $command .= "TZ='" . $_SESSION['tz'] . "' ";
 
   $command .= $rrdtool . 
-    " xport -t --start '" . $rrdtool_graph_start . 
+    " xport --start '" . $rrdtool_graph_start . 
     "' --end '" .  $rrdtool_graph_end . "' " .
     ($step ? " --step '" . $step . "' " : '') .
     ($maxRows ? " --maxrows '" . $maxRows . "' " : '') . 


### PR DESCRIPTION
Apache error log was reporting _ERROR: xport: invalid option -- 't'_. Also, both CVS and JSON exports were empty.

I'm pretty sure that the '-t' option was just a typo from the code cleanup in 1de9cf2a2875edc0266a9a01a52ccc3d96bdd2b6