### PR TITLE
Do not show current Grid in 'Choose a Source.'

### DIFF
--- a/graph.d/cpu_report.php
+++ b/graph.d/cpu_report.php
@@ -239,7 +239,7 @@ function graph_cpu_report( &$rrdtool_graph ) {
                         . "VDEF:steal_min=steal_pos,MINIMUM "
                         . "VDEF:steal_avg=steal_pos,AVERAGE "
                         . "VDEF:steal_max=steal_pos,MAXIMUM "
-                        . "GPRINT:'steal_last':'  ${space1}Now\:%5.1lf%%' "
+                        . "GPRINT:'steal_last':' ${space1}Now\:%5.1lf%%' "
                         . "GPRINT:'steal_min':'${space1}Min\:%5.1lf%%${eol1}' "
                         . "GPRINT:'steal_avg':'${space2}Avg\:%5.1lf%%' "
                         . "GPRINT:'steal_max':'${space1}Max\:%5.1lf%%\\l' ";

--- a/graph.d/mem_report.php
+++ b/graph.d/mem_report.php
@@ -138,7 +138,7 @@ function graph_mem_report ( &$rrdtool_graph ) {
                     . "VDEF:free_min=free_pos,MINIMUM " 
                     . "VDEF:free_avg=free_pos,AVERAGE " 
                     . "VDEF:free_max=free_pos,MAXIMUM " 
-                    . "GPRINT:'free_last':' ${space1}Now\:%6.1lf%s' "
+                    . "GPRINT:'free_last':'  ${space1}Now\:%6.1lf%s' "
                     . "GPRINT:'free_min':'${space1}Min\:%6.1lf%s${eol1}' "
                     . "GPRINT:'free_avg':'${space2}Avg\:%6.1lf%s' "
                     . "GPRINT:'free_max':'${space1}Max\:%6.1lf%s\\l' ";

--- a/header.php
+++ b/header.php
@@ -203,7 +203,7 @@ function make_node_menu($self,
     $node_menu .= "<option value=\"\">--Choose a Source\n";
     ksort($grid);
     foreach ($grid as $k => $v) {
-      if ($k == $self and $context != 'meta') continue;
+      if ($k == $self and isset($v['GRID']) and $v['GRID']) continue;
       if (isset($v['GRID']) and $v['GRID']) {
         $url = $v['AUTHORITY'];
         $node_menu .="<option value=\"$url\">$k ${conf['meta_designator']}\n";


### PR DESCRIPTION
The 'Choose a Source' button was listing the current Grid. This returns the behavior back to before 2164f3fb3b3a77f2501627400d406dffdcb9578, where the current Grid was not shown in the list. This also fixes the problem that 2164f3fb3b3a77f2501627400d406dffdcb9578 was attempting to address, where a cluster with the same name as a grid would get filtered out. 

The logic of 2164f3fb3b3a77f2501627400d406dffdcb9578 was flawed because $context is always "meta" at that point, making the _if_ statement always false.

Now it checks if the name is the same as the current grid and if it is a grid, is so, then skip it.
