### PR TITLE
Various maintenance tasks

### DIFF
--- a/actions.php
+++ b/actions.php
@@ -10,7 +10,7 @@ if ( isset($_GET['action']) && $_GET['action'] == "show_views" ) {
   $available_views = get_available_views();
   ?>
 
-  <table>
+  <table style="text-align:left;" cellpadding="5">
   <?php
   if ( isset($_GET['aggregate']) ) {
   ?>
@@ -19,17 +19,16 @@ if ( isset($_GET['action']) && $_GET['action'] == "show_views" ) {
   <?php
     } else {
   ?>
-     <tr><th>Hostname</th><td><?php print htmlspecialchars($_GET['host_name']); ?></td></tr>
-     <tr><th>Metric/Report</th><td><?php print htmlspecialchars($_GET['metric_name']); ?></td></tr>
+     <tr><th>Host name</th><td><?php print htmlspecialchars($_GET['host_name']); ?></td></tr>
+     <tr><th><?php print ucfirst($_GET['type']); ?></th><td><?php print htmlspecialchars($_GET['metric_name']); ?></td></tr>
   <?php
   }
   ?>
-
   </table>
   <p>
   <form id="add_metric_to_view_form">
     Add graph to view: <br />
-    <?php 
+    <?php
     // Get all the aggregate form variables and put them in the hidden fields
     if ( isset($_GET['aggregate']) ) {
 	foreach ( $_GET as $key => $value ) {
@@ -51,9 +50,10 @@ if ( isset($_GET['action']) && $_GET['action'] == "show_views" ) {
 	  print "<input type=\"hidden\" name=\"vertical_label\" value=\"" . htmlentities(stripslashes($_GET['vl'])) . "\" />";
       if (isset($_GET['ti']) && ($_GET['ti'] !== ''))
 	  print "<input type=\"hidden\" name=\"title\" value=\"" . htmlentities(stripslashes($_GET['ti'])) . "\" />";
-      
-      print "<table><tr><th rowspan=2>Optional thresholds to display</th><td>Warning</td><td><input size=6 name=\"warning\"></td>
-	</tr><td>Critical</td><td><input size=6 name=\"critical\"></td></tr></table>";
+    }
+
+  if (isset($_GET['type']) && $_GET['type'] == 'metric') {
+      print "<table style=\"text-align:left;\" cellpadding=\"5\"><tr><th rowspan=2>Optional thresholds to display</th><td>Warning</td><td><input size=6 name=\"warning\"></td></tr><td>Critical</td><td><input size=6 name=\"critical\"></td></tr></table>";
     }
     ?>
     <br />
@@ -68,7 +68,7 @@ if ( isset($_GET['action']) && $_GET['action'] == "show_views" ) {
     ksort($sorted_views);
     foreach ($sorted_views as $view_name => $view) {
       print "<option value=\"" . $view_name . "\">" . $view_name . "</option>";
-    } 
+    }
     ?>
     </select>
     </center>

--- a/graph.php
+++ b/graph.php
@@ -7,8 +7,8 @@ include_once "./eval_conf.php";
 include_once "./get_context.php";
 include_once "./functions.php";
 
-function add_total_to_cdef($cdef, 
-			   $total_ids, 
+function add_total_to_cdef($cdef,
+			   $total_ids,
 			   $graph_config_scale) {
   // Percentage calculation for cdefs, if required
   $total = " CDEF:'total'=";
@@ -25,17 +25,17 @@ function add_total_to_cdef($cdef,
     $total .= $total_ids[0];
     foreach ($total_ids as $total_id)
       $total .= ',' . $total_id . ',ADDNAN';
-    
+
     if (isset($graph_config['scale']))
       $total .= ",${graph_config_scale},*";
-    
+
     // Prepend total calculation
     $cdef = $total . ', ' . $cdef;
   }
   return $cdef;
 }
 
-function graphdef_add_series($graphdef, 
+function graphdef_add_series($graphdef,
 			     $series,
 			     $series_type,
 			     $graph_config_percent,
@@ -46,17 +46,17 @@ function graphdef_add_series($graphdef,
 			     $conf_graphreport_stats,
 			     $conf_graphreport_stat_items) {
   static $line_widths = array("1", "2", "3");
-  
+
   $label = str_pad(sanitize($series['label']), $max_label_length);
   switch ($series_type) {
   case "line":
     // Make sure it's a recognized line type
-    $line_width = isset($series['line_width']) && 
-      in_array($series['line_width'], $line_widths) ? 
+    $line_width = isset($series['line_width']) &&
+      in_array($series['line_width'], $line_widths) ?
       $series['line_width'] : '1';
     $graphdef .= "LINE" . $line_width;
     $graphdef .= ":'";
-    if (isset($graph_config_percent) && 
+    if (isset($graph_config_percent) &&
 	$graph_config_percent == '1') {
       $graphdef .= "p";
     } else if (isset($graph_config_scale)) {
@@ -64,7 +64,7 @@ function graphdef_add_series($graphdef,
     }
     $graphdef .= "${series_id}'#${series['color']}:'${label}' ";
     break;
-    
+
   case "stack":
   case "percent":
     // First element in a stack has to be AREA
@@ -75,7 +75,7 @@ function graphdef_add_series($graphdef,
       $graphdef .= "STACK";
     }
     $graphdef .= ":'";
-    if (isset($graph_config_percent) && 
+    if (isset($graph_config_percent) &&
 	$graph_config_percent == '1') {
       $graphdef .= "p";
     } else if (isset($graph_config_scale)) {
@@ -83,19 +83,19 @@ function graphdef_add_series($graphdef,
     }
     $graphdef .= "${series_id}'#${series['color']}:'${label}' ";
     break;
-  
+
     // Percentile lines
   case "percentile":
-    $percentile = isset($series['percentile']) ? 
+    $percentile = isset($series['percentile']) ?
       floatval($series['percentile']): 95;
     $graphdef .= "VDEF:t${series_id}=${series_id},${percentile},PERCENT ";
-    $line_width = isset($series['line_width']) && 
-      in_array($series['line_width'], $line_widths) ? 
+    $line_width = isset($series['line_width']) &&
+      in_array($series['line_width'], $line_widths) ?
       $series['line_width'] : '1';
-    $graphdef .= "LINE" . $line_width . 
+    $graphdef .= "LINE" . $line_width .
       ":'t$series_id'#{$series['color']}:'{$label}':dashes ";
     break;
-    
+
   case "area":
     $graphdef .= "AREA";
     $graphdef .= ":'$series_id'#${series['color']}:'${label}' ";
@@ -104,7 +104,7 @@ function graphdef_add_series($graphdef,
 
   if ($conf_graphreport_stats) {
     $id = $series_id;
-    if (isset($graph_config_percent) && 
+    if (isset($graph_config_percent) &&
 	$graph_config_percent == '1') {
       $id = 'p' . $id;
     } else if (isset($graph_config_scale)) {
@@ -112,7 +112,7 @@ function graphdef_add_series($graphdef,
     }
     $graphdef .= legendEntry($id, $conf_graphreport_stat_items);
   }
-  
+
   return array($graphdef, $stack_counter);
 }
 
@@ -126,34 +126,34 @@ function rrdtool_graph_merge_args_from_json($rrdtool_graph,
 					    $conf_rrds,
 					    $conf_graphreport_stats,
 					    $conf_graphreport_stat_items) {
-					    
+
   $title = sanitize($graph_config['title']);
-  $rrdtool_graph['title'] = $title; 
-  // If vertical label is empty or non-existent set it to space otherwise 
+  $rrdtool_graph['title'] = $title;
+  // If vertical label is empty or non-existent set it to space otherwise
   // rrdtool will fail
-  if (! isset($graph_config['vertical_label']) || 
+  if (! isset($graph_config['vertical_label']) ||
       $graph_config['vertical_label'] == "") {
-     $rrdtool_graph['vertical-label'] = " ";   
+     $rrdtool_graph['vertical-label'] = " ";
   } else {
-    $rrdtool_graph['vertical-label'] = 
+    $rrdtool_graph['vertical-label'] =
       sanitize($graph_config['vertical_label']);
   }
-  
+
   $rrdtool_graph['lower-limit'] = '0';
-  
+
   if (isset($graph_config['height_adjustment']) ) {
-    $rrdtool_graph['height'] += 
+    $rrdtool_graph['height'] +=
       ($size == 'medium') ? $graph_config['height_adjustment'] : 0;
   } else {
     $rrdtool_graph['height'] += ($size == 'medium') ? 28 : 0;
-  } 
-  
-  // find longest label length, so we pad the others accordingly to get 
+  }
+
+  // find longest label length, so we pad the others accordingly to get
   // consistent column alignment
   $max_label_length = 0;
   foreach($graph_config['series'] as $series)
     $max_label_length = max(strlen($series['label']), $max_label_length);
-  
+
   $seriesdef = '';
   $cdef = '';
   $graphdef = '';
@@ -163,30 +163,30 @@ function rrdtool_graph_merge_args_from_json($rrdtool_graph,
   // Loop through all the graph series
   foreach ($graph_config['series'] as $series_id => $series) {
     // ignore series if context is not defined in json template
-    if (isset($series['contexts']) and 
+    if (isset($series['contexts']) and
 	!in_array($context, $series['contexts']))
       continue;
 
-    $rrd_dir = $conf_rrds . "/" . 
-      $series['clustername'] . "/" . 
+    $rrd_dir = $conf_rrds . "/" .
+      $series['clustername'] . "/" .
       $series['hostname'];
-    
+
     $metric = sanitize($series['metric']);
     $metric_file = $rrd_dir . "/" . $metric . ".rrd";
-    
+
     // Make sure metric file exists. Otherwise we'll get a broken graph
     if (is_file($metric_file)) {
       // Need this when defining graphs that may use same metric names
       $unique_id = "a" . $series_id;
       $total_ids[] = $unique_id;
-        
-      // use custom DS defined in json template if it's 
+
+      // use custom DS defined in json template if it's
       // defined (default = 'sum')
       $DS = isset($series['ds']) ? sanitize($series['ds']) : 'sum';
       $seriesdef .= " DEF:'$unique_id'='$metric_file':'$DS':AVERAGE ";
 
       if (isset($graph_config['scale']))
-	$cdef .= 
+	$cdef .=
 	  " CDEF:'s${unique_id}'=${unique_id},${graph_config['scale']},* ";
 
       if (isset($graph_config['percent']) && $graph_config['percent'] == '1')
@@ -194,9 +194,9 @@ function rrdtool_graph_merge_args_from_json($rrdtool_graph,
 
       // By default graph is a line graph
       $series_type = isset($series['type']) ? $series['type'] : "line";
-      
+
       list($graphdef, $stack_counter) =
-	graphdef_add_series($graphdef, 
+	graphdef_add_series($graphdef,
 			    $series,
 			    $series_type,
 			    $graph_config['percent'],
@@ -209,10 +209,10 @@ function rrdtool_graph_merge_args_from_json($rrdtool_graph,
     } // end of if (is_file($metric_file))
   }
 
-  $show_total = isset($graph_config['show_total']) && 
+  $show_total = isset($graph_config['show_total']) &&
     ($graph_config['show_total'] == 1);
   if ($show_total ||
-      (isset($graph_config['percent']) && 
+      (isset($graph_config['percent']) &&
        $graph_config['percent'] == '1')) {
     $cdef = add_total_to_cdef($cdef,
 			      $total_ids,
@@ -224,32 +224,32 @@ function rrdtool_graph_merge_args_from_json($rrdtool_graph,
     }
   }
 
-  // If we end up with the empty series it means that no RRD files matched. 
-  // This can happen if we are trying to create a report and metrics for 
-  // this host were not collected. If that happens we should create an 
+  // If we end up with the empty series it means that no RRD files matched.
+  // This can happen if we are trying to create a report and metrics for
+  // this host were not collected. If that happens we should create an
   // empty graph
   if ($seriesdef == "") {
-    $rrdtool_graph['series'] = 
-      'HRULE:1#FFCC33:"No matching metrics detected or RRDs not readable"';   
+    $rrdtool_graph['series'] =
+      'HRULE:1#FFCC33:"No matching metrics detected or RRDs not readable"';
   } else {
     $rrdtool_graph['series'] = $seriesdef . ' ' . $cdef . ' ' . $graphdef;
   }
-  
+
   return $rrdtool_graph;
 }
 
 function build_aggregate_graph_config_from_url($conf_graph_colors) {
   // If graph type is not specified default to line graph
-  $graph_type = isset($_GET["gtype"]) && 
+  $graph_type = isset($_GET["gtype"]) &&
     in_array($_GET["gtype"], array("stack", "line", "percent")) ?
     $_GET["gtype"] : 'line';
 
   // If line width not specified default to 2
-  $line_width = isset($_GET["lw"]) && 
+  $line_width = isset($_GET["lw"]) &&
     in_array($_GET["lw"], array("1", "2", "3")) ?
     $_GET["lw"] : '2';
 
-  $graph_legend = isset($_GET["glegend"]) && 
+  $graph_legend = isset($_GET["glegend"]) &&
     in_array($_GET["glegend"], array("show", "hide")) ?
     $_GET["glegend"] : 'show';
 
@@ -261,10 +261,10 @@ function build_aggregate_graph_config_from_url($conf_graph_colors) {
   if (isset($_GET['hl'])) {
     $counter = 0;
     $color_count = count($conf_graph_colors);
-    $metric_name = str_replace("$", 
-			       "", 
-			       str_replace("^", 
-					   "", 
+    $metric_name = str_replace("$",
+			       "",
+			       str_replace("^",
+					   "",
 					   $_GET['mreg'][0]));
     $host_list = explode(",", $_GET['hl']);
     foreach ($host_list as $host_cluster) {
@@ -275,10 +275,10 @@ function build_aggregate_graph_config_from_url($conf_graph_colors) {
 
       $series = array("hostname" => $hostname,
                       "clustername" => $clustername,
-                      "fill" => "true", 
-                      "metric" => $metric_name,  
-                      "color" => $conf_graph_colors[$color_index], 
-                      "label" => $hostname, 
+                      "fill" => "true",
+                      "metric" => $metric_name,
+                      "color" => $conf_graph_colors[$color_index],
+                      "label" => $hostname,
                       "type" => $graph_type);
 
       if ($graph_type == "line" || $graph_type == "area") {
@@ -289,12 +289,12 @@ function build_aggregate_graph_config_from_url($conf_graph_colors) {
         $series['stack'] = "1";
       }
       $graph_config['series'][] = $series;
-      
+
       $counter++;
-    } 
+    }
   } else {
-    $exclude_host_from_legend_label = 
-      (array_key_exists('lgnd_xh', $_GET) && 
+    $exclude_host_from_legend_label =
+      (array_key_exists('lgnd_xh', $_GET) &&
        $_GET['lgnd_xh'] == "true") ? TRUE : FALSE;
 
     $sortit = true;
@@ -302,25 +302,25 @@ function build_aggregate_graph_config_from_url($conf_graph_colors) {
       $sortit = false;
     }
 
-    $graph_config = 
-      build_aggregate_graph_config($graph_type, 
-				   $line_width, 
-				   $_GET['hreg'], 
+    $graph_config =
+      build_aggregate_graph_config($graph_type,
+				   $line_width,
+				   $_GET['hreg'],
 				   $_GET['mreg'],
 				   $graph_legend,
 				   $exclude_host_from_legend_label,
                                    $sortit);
   }
 
-  // Set up 
+  // Set up
   $graph_config["report_type"] = "standard";
-  $graph_config["vertical_label"] =  isset($_GET["vl"]) ? 
+  $graph_config["vertical_label"] =  isset($_GET["vl"]) ?
     sanitize($_GET["vl"])  : NULL;
-  $graph_config["graph_scale"] = isset($_GET["gs"]) ? 
+  $graph_config["graph_scale"] = isset($_GET["gs"]) ?
     sanitize($_GET["gs"]) : NULL;
   $graph_config["scale"] = isset($_GET["scale"]) ?
     sanitize($_GET["scale"]) : NULL;
-  $graph_config["show_total"] = isset($_GET["show_total"]) ? 
+  $graph_config["show_total"] = isset($_GET["show_total"]) ?
     sanitize($_GET["show_total"]) : NULL;
   if (isset($_GET['title']) && $_GET['title'] != "")
     $graph_config["title"] = sanitize($_GET['title']);
@@ -352,7 +352,7 @@ function rrdtool_graph_build_view_graph($rrdtool_graph,
     if ($item_id == $view_item['item_id'])
       break;
   }
-  $rrdtool_graph = 
+  $rrdtool_graph =
     rrdtool_graph_merge_args_from_json($rrdtool_graph,
 				       $view_item,
 				       $context,
@@ -369,7 +369,7 @@ function rrdtool_graph_build_view_graph($rrdtool_graph,
 function build_graphite_series($context, $graph_config, $host_cluster = "") {
   $targets = array();
   $colors = array();
-  
+
   // Keep track of stacked items
   $stacked = 0;
 
@@ -382,22 +382,22 @@ function build_graphite_series($context, $graph_config, $host_cluster = "") {
       $stacked++;
 
     if (isset($item['hostname']) && isset($item['clustername'])) {
-      $host_cluster = $item['clustername'] . "." . 
+      $host_cluster = $item['clustername'] . "." .
 	str_replace(".", "_", $item['hostname']);
     }
 
-    $targets[] = 
-      "target=". urlencode("alias(" . 
-			   $host_cluster . "." . 
-			   $item['metric'] . 
-			   ".sum,'" . $item['label'] . 
+    $targets[] =
+      "target=". urlencode("alias(" .
+			   $host_cluster . "." .
+			   $item['metric'] .
+			   ".sum,'" . $item['label'] .
 			   "')");
     $colors[] = $item['color'];
   }
   $series = implode($targets, '&');
   $series .= "&colorList=" . implode($colors, ',');
-  $series .= "&vtitle=" . 
-    urlencode(isset($graph_config['vertical_label']) ? 
+  $series .= "&vtitle=" .
+    urlencode(isset($graph_config['vertical_label']) ?
 	      $graph_config['vertical_label'] : "");
 
   // Do we have any stacked elements. We assume if there is only one element
@@ -408,7 +408,7 @@ function build_graphite_series($context, $graph_config, $host_cluster = "") {
     else
       $series .= "&areaMode=first";
   }
-  
+
   return $series;
 }
 
@@ -431,28 +431,28 @@ function build_graphite_url($rrd_graphite_link,
 			    $max,
 			    $title,
 			    $range) {
-  // Check whether the link exists from Ganglia RRD tree to the graphite 
+  // Check whether the link exists from Ganglia RRD tree to the graphite
   // storage/rrd_dir area
   if (! is_link($rrd_graphite_link)) {
     // Does the directory exist for the cluster. If not create it
-    if (! is_dir($conf['graphite_rrd_dir'] . "/" . 
+    if (! is_dir($conf['graphite_rrd_dir'] . "/" .
 		 str_replace(" ", "_", $clustername)) )
-      mkdir($conf['graphite_rrd_dir'] . "/" . 
+      mkdir($conf['graphite_rrd_dir'] . "/" .
 	    str_replace(" ", "_", $clustername));
     symlink($rrd_dir, str_replace(" ", "_", $rrd_graphite_link));
   }
-  
+
   // Generate host cluster string
   if (isset($clustername))
     $host_cluster = str_replace(" ", "_", $clustername) . "." . $host;
   else
     $host_cluster = $host;
-  
+
   $height += 70;
-  
+
   if ($size == "small")
     $width += 20;
-  
+
   // If graph_config is already set we can use it immediately
   if (isset($graph_config)) {
     $target = build_graphite_series($context, $graph_config, "");
@@ -461,7 +461,7 @@ function build_graphite_url($rrd_graphite_link,
       // if it's a report increase the height for additional 30 pixels
       $height += 40;
       $report_name = sanitize($_GET['g']);
-      $report_definition_file = $conf['gweb_root'] . "/graph.d/" . 
+      $report_definition_file = $conf['gweb_root'] . "/graph.d/" .
 	$report_name . ".json";
       // Check whether report is defined in graph.d directory
       if (is_file($report_definition_file)) {
@@ -471,29 +471,29 @@ function build_graphite_url($rrd_graphite_link,
 	error_log("There is JSON config file specifying $report_name.");
 	exit(1);
       }
-    
+
       if (isset($graph_config)) {
 	switch ($graph_config["report_type"]) {
         case "template":
-          $target = str_replace("HOST_CLUSTER", 
+          $target = str_replace("HOST_CLUSTER",
 				$conf['graphite_prefix'] . $host_cluster,
 				$graph_config["graphite"]);
           break;
-    
+
         case "standard":
-          $target = 
-	    build_graphite_series($context, 
-				  $graph_config, 
+          $target =
+	    build_graphite_series($context,
+				  $graph_config,
 				  $conf['graphite_prefix'] . $host_cluster);
           break;
-    
+
         default:
           error_log("No valid report_type specified in the " .
                     $report_name .
                     " definition.");
           break;
 	}
-	
+
 	$title = $graph_config['title'];
       } else {
 	error_log("Configuration file to $report_name exists; " .
@@ -503,29 +503,29 @@ function build_graphite_url($rrd_graphite_link,
     } else {
       // It's a simple metric graph
       $vlabel = isset($_GET["vl"]) ? sanitize($_GET["vl"])  : NULL;
-      $target = "target=" . $conf['graphite_prefix'] . 
-	"$host_cluster.$metric_name.sum&hideLegend=true&vtitle=" . 
-	urlencode($vlabel) . 
+      $target = "target=" . $conf['graphite_prefix'] .
+	"$host_cluster.$metric_name.sum&hideLegend=true&vtitle=" .
+	urlencode($vlabel) .
 	"&areaMode=all&colorList=". $conf['default_metric_color'];
       $title = " ";
     }
-  } 
-    
-  if ($cs) 
+  }
+
+  if ($cs)
     $start = date("H:i_Ymd", tzTimeToTimestamp($cs));
 
-  if ($ce) 
+  if ($ce)
     $end = date("H:i_Ymd", tzTimeToTimestamp($ce));
 
-  if ($max == 0) 
+  if ($max == 0)
     $max = "";
 
-  $graphite_url = $conf['graphite_url_base'] . 
-    "?width=$width&height=$height&" . 
-    $target . 
-    "&from=" . $start . "&until=" . $end . 
-    "&yMin=" . $min . "&yMax=" . $max . 
-    "&bgcolor=FFFFFF&fgcolor=000000&title=" . 
+  $graphite_url = $conf['graphite_url_base'] .
+    "?width=$width&height=$height&" .
+    $target .
+    "&from=" . $start . "&until=" . $end .
+    "&yMin=" . $min . "&yMax=" . $max .
+    "&bgcolor=FFFFFF&fgcolor=000000&title=" .
     urlencode($title . " last " . $range);
 
   return $graphite_url;
@@ -554,27 +554,27 @@ function get_timestamp($time) {
   return $timestamp;
 }
 
-function get_nagios_events($overlay_nagios_base_url, 
+function get_nagios_events($overlay_nagios_base_url,
 			   $host,
 			   $start,
 			   $end) {
   $nagios_events = array();
-  $nagios_pull_url = 
-    $overlay_nagios_base_url . 
+  $nagios_pull_url =
+    $overlay_nagios_base_url .
     '/cgi-bin/api.cgi?action=host.gangliaevents' .
     '&host=' . urlencode($host) .
-    '&start=' . urlencode($start) . 
+    '&start=' . urlencode($start) .
     '&end=' . urlencode($end);
-  $raw_nagios_events = 
+  $raw_nagios_events =
     @file_get_contents(
       $nagios_pull_url,
       0,
-      stream_context_create(array('http' => array('timeout' => 5), 
+      stream_context_create(array('http' => array('timeout' => 5),
 				  'https' => array('timeout' => 5))));
   if (strlen($raw_nagios_events) > 3) {
     $nagios_events = json_decode($raw_nagios_events, TRUE);
     // Handle any "ERROR" formatted messages and wipe resulting array.
-    if (isset($nagios_events['response_type']) && 
+    if (isset($nagios_events['response_type']) &&
         $nagios_events['response_type'] == 'ERROR') {
       $nagios_events = array();
     }
@@ -608,20 +608,20 @@ function rrdgraph_cmd_add_overlay_events($command,
   // Get array of events for time range
   $events_array = ganglia_events_get($graph_start_timestamp,
 				     $graph_end_timestamp);
-  
+
   if (empty($events_array))
     return $command;
-  
+
   $event_color_json = file_get_contents($conf_overlay_events_color_map_file);
-  if ($debug) 
+  if ($debug)
     error_log("$event_color_json");
   $event_color_array = json_decode($event_color_json, TRUE);
   $initial_event_color_count = count($event_color_array);
   $event_color_map = array();
   foreach ($event_color_array as $event_color_entry) {
-    $event_color_map[$event_color_entry['summary']] = 
+    $event_color_map[$event_color_entry['summary']] =
       $event_color_entry['color'];
-    if ($debug) 
+    if ($debug)
       error_log("Adding event color to map: " .
 		$event_color_entry['summary'] .
 		' ' .
@@ -665,19 +665,19 @@ function rrdgraph_cmd_add_overlay_events($command,
     }
 
     unset($evt_end);
-    if (array_key_exists('end_time', $event) && 
+    if (array_key_exists('end_time', $event) &&
 	is_numeric($event['end_time'])) {
       $evt_end = $event['end_time'];
     }
 
-    // If event start is less than start bail out of the loop since 
-    // there is nothing more to do since events are sorted in reverse 
-    // chronological order and these events are not gonna show up in 
+    // If event start is less than start bail out of the loop since
+    // there is nothing more to do since events are sorted in reverse
+    // chronological order and these events are not gonna show up in
     // the graph
     $in_graph = (($evt_start >= $graph_start_timestamp) &&
 		 ($evt_start <= $graph_end_timestamp)) ||
-      (isset($evt_end) && 
-       ($evt_end >= $graph_start_timestamp) && 
+      (isset($evt_end) &&
+       ($evt_end >= $graph_start_timestamp) &&
        ($evt_start <= $graph_end_timestamp));
     if (!$in_graph) {
       if ($debug)
@@ -693,7 +693,7 @@ function rrdgraph_cmd_add_overlay_events($command,
       $evt_start = $graph_start_timestamp;
       $evt_start_in_graph_range = FALSE;
     }
- 
+
     $evt_end_in_graph_range = TRUE;
     if (isset($evt_end)) {
       if ($evt_end > $graph_end_timestamp) {
@@ -702,15 +702,15 @@ function rrdgraph_cmd_add_overlay_events($command,
       }
     } else
       $evt_end_in_graph_range = FALSE;
-	
+
     if (preg_match("/" . $event["host_regex"] . "/", $original_command)) {
       if ($evt_start >= $graph_start_timestamp) {
-	// Do we have the end timestamp. 
+	// Do we have the end timestamp.
 	if (!isset($graph_end_timestamp) ||
 	    ($evt_start < $graph_end_timestamp)) {
-	  // This is a potential vector since this gets added to the 
+	  // This is a potential vector since this gets added to the
 	  // command line_width TODO: Look over sanitize
-	  $summary = 
+	  $summary =
 	    isset($event['summary']) ? sanitize($event['summary']) : "";
 
 	  // We need to keep track of summaries so that if we have identical
@@ -737,30 +737,30 @@ function rrdgraph_cmd_add_overlay_events($command,
 	      error_log("process_overlay_events: " .
 			"Adding new event color: $summary $color");
 	  }
-  
+
 	  if (isset($evt_end)) {
 	    // Attempt to draw a shaded area between start and end points.
 	    // Force solid line for ranges
 	    $overlay_events_line_type = "";
-	    
+
 	    $start_vrule = '';
 	    if ($evt_start_in_graph_range)
 	      $start_vrule = " VRULE:" . $evt_start .
 		"#$color" . $conf_overlay_events_tick_alpha .
 		":\"" . $summary . "\"" . $overlay_events_line_type;
-	    
+
 	    $end_vrule = '';
 	    if ($evt_end_in_graph_range)
 	      $end_vrule = " VRULE:" . $evt_end .
 		"#$color" . $conf_overlay_events_tick_alpha .
 		':""' . $overlay_events_line_type;
-	    
+
 	    // We need a dummpy DEF statement, because RRDtool is too stupid
 	    // to plot graphs without a DEF statement.
 	    // We can't count on a static name, so we have to "find" one.
 	    if (preg_match("/DEF:['\"]?(\w+)['\"]?=/", $command, $matches)) {
 	      // stupid rrdtool limitation.
-	      $area_cdef = 
+	      $area_cdef =
 		" CDEF:area_$counter=$matches[1],POP," .
 		"TIME,$evt_start,GT,1,UNKN,IF,TIME,$evt_end,LT,1,UNKN,IF,+";
 	      $area_shade = $color . $conf_overlay_events_shade_alpha;
@@ -777,7 +777,7 @@ function rrdgraph_cmd_add_overlay_events($command,
 	  }
 	  $counter++;
 	} else {
-	  if ($debug)  
+	  if ($debug)
 	    error_log("process_overlay_events: " .
 		      "Event start [$evt_start] >= graph end " .
 		      "[$graph_end_timestamp]");
@@ -853,17 +853,17 @@ function rrdgraph_cmd_build($rrdtool_graph,
 			    $context,
 			    $grid,
 			    $raw_host,
-			    $graph, 
+			    $graph,
 			    $graph_arguments) {
   if (! isset($graph_config)) {
     $php_report_file = $conf['graphdir'] . "/" . $graph . ".php";
     $json_report_file = $conf['graphdir'] . "/" . $graph . ".json";
-    
+
     if (is_file($php_report_file)) {
-      // Check for path traversal issues by making sure real path is 
+      // Check for path traversal issues by making sure real path is
       // actually in graphdir
       if (dirname(realpath($php_report_file)) !=  $conf['graphdir']) {
-	$rrdtool_graph['series'] = 
+	$rrdtool_graph['series'] =
 	  'HRULE:1#FFCC33:"Check \$conf[graphdir] should not be relative path"';
       } else {
 	$graph_function = "graph_${graph}";
@@ -879,12 +879,12 @@ function rrdgraph_cmd_build($rrdtool_graph,
       }
     } else if (is_file($json_report_file )) {
       if (dirname(realpath($json_report_file)) !=  $conf['graphdir']) {
-	$rrdtool_graph['series'] = 
+	$rrdtool_graph['series'] =
 	  'HRULE:1#FFCC33:"Check \$conf[graphdir] should not be relative path"';
       } else {
-	$graph_config = 
+	$graph_config =
 	  json_decode(file_get_contents($json_report_file), TRUE );
-	
+
 	// We need to add hostname and clustername if it's not specified
 	foreach (array_keys($graph_config['series']) as $series_id) {
 	  if (! isset($graph_config['series'][$index]['hostname'])) {
@@ -892,12 +892,12 @@ function rrdgraph_cmd_build($rrdtool_graph,
 	    if (isset($grid))
 	      $graph_config['series'][$series_id]['clustername'] = $grid;
 	    else
-	      $graph_config['series'][$series_id]['clustername'] = 
+	      $graph_config['series'][$series_id]['clustername'] =
 		$user_clustername;
 	  }
 	}
 
-	$rrdtool_graph = 
+	$rrdtool_graph =
 	  rrdtool_graph_merge_args_from_json($rrdtool_graph,
 					     $graph_config,
 					     $context,
@@ -907,8 +907,8 @@ function rrdgraph_cmd_build($rrdtool_graph,
 					     $conf['graphreport_stat_items']);
       }
     }
-  } else { 
-    $rrdtool_graph = 
+  } else {
+    $rrdtool_graph =
       rrdtool_graph_merge_args_from_json($rrdtool_graph,
 					 $graph_config,
 					 $context,
@@ -917,30 +917,30 @@ function rrdgraph_cmd_build($rrdtool_graph,
 					 $conf['graphreport_stats'],
 					 $conf['graphreport_stat_items']);
   }
-  
+
   // We must have a 'series' value, or this is all for naught
-  if (!array_key_exists('series', $rrdtool_graph) || 
+  if (!array_key_exists('series', $rrdtool_graph) ||
       !strlen($rrdtool_graph['series'])) {
-    $rrdtool_graph['series'] = 
+    $rrdtool_graph['series'] =
       'HRULE:1#FFCC33:"Empty RRDtool command. Likely bad graph config"';
   }
-  
+
   // Make small graphs (host list) cleaner by removing the too-big
   // legend: it is displayed above on larger cluster summary graphs.
   if (($size == "small" and ! isset($subtitle)) ||
       ($graph_config["glegend"] == "hide"))
-    $rrdtool_graph['extras'] = isset($rrdtool_graph['extras']) ? 
+    $rrdtool_graph['extras'] = isset($rrdtool_graph['extras']) ?
       $rrdtool_graph['extras'] . " -g" : " -g" ;
 
   // add slope-mode if rrdtool_slope_mode is set
-  if (isset($conf['rrdtool_slope_mode']) && 
+  if (isset($conf['rrdtool_slope_mode']) &&
       $conf['rrdtool_slope_mode'] == TRUE)
     $rrdtool_graph['slope-mode'] = '';
-  
+
   if (isset($rrdtool_graph['title']) && isset($title)) {
     if ($conf['decorated_graph_title'])
-      $rrdtool_graph['title'] = $title . " " . 
-	$rrdtool_graph['title'] . 
+      $rrdtool_graph['title'] = $title . " " .
+	$rrdtool_graph['title'] .
 	" last $range";
   }
 
@@ -948,10 +948,10 @@ function rrdgraph_cmd_build($rrdtool_graph,
   if (isset($_SESSION['tz']) && ($_SESSION['tz'] != ''))
     $command .= "TZ='" . $_SESSION['tz'] . "' ";
 
-  $command .= 
-    $conf['rrdtool'] . 
-    " graph" . 
-    (isset($_GET["verbose"]) ? 'v' : '') . 
+  $command .=
+    $conf['rrdtool'] .
+    " graph" .
+    (isset($_GET["verbose"]) ? 'v' : '') .
     " - $rrd_options ";
 
   // Look ahead six months
@@ -971,25 +971,25 @@ function rrdgraph_cmd_build($rrdtool_graph,
   if ($min)
     $rrdtool_graph['lower-limit'] = $min;
 
-  if (isset($graph_config['percent']) && 
+  if (isset($graph_config['percent']) &&
       $graph_config['percent'] == '1' ) {
     $rrdtool_graph['upper-limit'] = 100;
     $rrdtool_graph['lower-limit'] = 0;
   }
 
-  if ($max || 
-      $min || 
+  if ($max ||
+      $min ||
       (isset($graph_config['percent']) && $graph_config['percent'] == '1'))
-    $rrdtool_graph['extras'] = isset($rrdtool_graph['extras']) ? 
+    $rrdtool_graph['extras'] = isset($rrdtool_graph['extras']) ?
       $rrdtool_graph['extras'] . " --rigid" : " --rigid" ;
 
   if (isset($graph_config['graph_scale'])) {
     // Log scale support
     if ($graph_config['graph_scale'] == 'log') {
-      $rrdtool_graph['extras'] = isset($rrdtool_graph['extras']) ? 
-	$rrdtool_graph['extras'] . " --logarithm --units=si" : 
+      $rrdtool_graph['extras'] = isset($rrdtool_graph['extras']) ?
+	$rrdtool_graph['extras'] . " --logarithm --units=si" :
 	" --logarithm --units=si" ;
-      if (!isset($rrdtool_graph['lower-limit']) || 
+      if (!isset($rrdtool_graph['lower-limit']) ||
 	  $rrdtool_graph['lower-limit'] < 1) {
 	// With log scale, the lower limit *has* to be 1 or greater.
 	$rrdtool_graph['lower-limit'] = 1;
@@ -1005,11 +1005,11 @@ function rrdgraph_cmd_build($rrdtool_graph,
 			      'MB',
 			      'GB',
 			      'bits',
-			      'Bits', 
+			      'Bits',
 			      'bits/s',
 			      'Bits/s'))) {
-    // Set graph base value to 1024 
-    $rrdtool_graph['extras'] = isset($rrdtool_graph['extras']) ? 
+    // Set graph base value to 1024
+    $rrdtool_graph['extras'] = isset($rrdtool_graph['extras']) ?
       $rrdtool_graph['extras'] . " --base=1024" : " --base=1024" ;
   }
 
@@ -1029,10 +1029,10 @@ function rrdgraph_cmd_build($rrdtool_graph,
     }
     $command .= " --$key $value";
   }
-  
+
   // And finish up with the two variables that need special handling.
   // See above for how these are created
-  $command .= array_key_exists('extras', $rrdtool_graph) ? 
+  $command .= array_key_exists('extras', $rrdtool_graph) ?
     ' ' . $rrdtool_graph['extras'] . ' ' : '';
   $command .= " $rrdtool_graph[series]";
   return array($command, $rrdtool_graph);
@@ -1055,8 +1055,8 @@ function output_data_to_external_format($rrdtool_graph_series,
 					$step,
 					$rrd_options) {
   // First find RRDtool DEFs by parsing $rrdtool_graph['series']
-  preg_match_all("/([^V]DEF|CDEF):(.*)(:AVERAGE|\s)/", 
-		 " " . $rrdtool_graph_series, 
+  preg_match_all("/([^V]DEF|CDEF):(.*)(:AVERAGE|\s)/",
+		 " " . $rrdtool_graph_series,
 		 $matches);
 
   $rrdtool_graph_args = "";
@@ -1065,7 +1065,7 @@ function output_data_to_external_format($rrdtool_graph_series,
   }
 
   preg_match_all("/(LINE[0-9]*|AREA|STACK):\'[^']*\'[^']*\'[^']*\'[^ ]* /",
-		 " " . $rrdtool_graph_series, 
+		 " " . $rrdtool_graph_series,
 		 $matches);
   foreach ($matches[0] as $value) {
     if (preg_match("/(LINE[0-9]*:\'|AREA:\'|STACK:\')([^']*)(\')([^']*)(\')([^']*)(')/", $value, $out)) {
@@ -1077,7 +1077,7 @@ function output_data_to_external_format($rrdtool_graph_series,
       $ds_attr = array("ds_name" => $ds_name,
 		       "cluster_name" => '',
 		       "graph_type" => $metric_type,
-		       "host_name" => '', 
+		       "host_name" => '',
 		       "metric_name" => $metric_name);
 
       // Add color if it exists
@@ -1085,18 +1085,18 @@ function output_data_to_external_format($rrdtool_graph_series,
       if ($pos_hash !== FALSE) {
 	$pos_colon = strpos($out[4], ':');
 	if ($pos_colon !== FALSE)
-	  $ds_attr['color'] = substr($out[4], 
-				     $pos_hash, 
-				     $pos_colon - $pos_hash); 
+	  $ds_attr['color'] = substr($out[4],
+				     $pos_hash,
+				     $pos_colon - $pos_hash);
 	else
-	  $ds_attr['color'] = substr($out[4], $pos_hash); 
+	  $ds_attr['color'] = substr($out[4], $pos_hash);
       }
 
       if (strpos($value, ":dashes") !== FALSE)
 	$ds_attr['dashes'] = 1;
 
       $output_array[] = $ds_attr;
-      $rrdtool_graph_args .=  
+      $rrdtool_graph_args .=
 	" " . "XPORT:'" . $ds_name . "':'" . $metric_name . "' ";
     }
   }
@@ -1104,18 +1104,18 @@ function output_data_to_external_format($rrdtool_graph_series,
   // This command will export values for the specified format in XML
 
   $maxRows = '';
-  if ($step) { 
+  if ($step) {
     /*
-      Allow a custom step, if it was specified by the user. 
-      Also, we need to specify a --maxrows in case the number 
-      of rows with $step end up being higher than 
-      rrdxport's default (in which case the step is changed 
-      to fit inside the default --maxrows), but we also need 
-      to guard against "underflow" because rrdxport craps out 
+      Allow a custom step, if it was specified by the user.
+      Also, we need to specify a --maxrows in case the number
+      of rows with $step end up being higher than
+      rrdxport's default (in which case the step is changed
+      to fit inside the default --maxrows), but we also need
+      to guard against "underflow" because rrdxport craps out
       when --maxrows is less than 10.
     */
 
-    $maxRows = max(10, round(($rrdtool_graph_end - 
+    $maxRows = max(10, round(($rrdtool_graph_end -
 			      $rrdtool_graph_start) / $step));
   } else if (isset($_GET['maxrows']) && is_numeric($_GET['maxrows'])) {
     $maxRows = max(10, $_GET['maxrows']);
@@ -1125,19 +1125,19 @@ function output_data_to_external_format($rrdtool_graph_series,
   if (isset($_SESSION['tz']) && ($_SESSION['tz'] != ''))
     $command .= "TZ='" . $_SESSION['tz'] . "' ";
 
-  $command .= $rrdtool . 
-    " xport --start '" . $rrdtool_graph_start . 
+  $command .= $rrdtool .
+    " xport -t --start '" . $rrdtool_graph_start .
     "' --end '" .  $rrdtool_graph_end . "' " .
     ($step ? " --step '" . $step . "' " : '') .
-    ($maxRows ? " --maxrows '" . $maxRows . "' " : '') . 
-    $rrd_options . " " . 
+    ($maxRows ? " --maxrows '" . $maxRows . "' " : '') .
+    $rrd_options . " " .
     $rrdtool_graph_args;
 
   // Read in the XML
   $string = "";
   if (strlen($command) < 100000) {
-    $fp = popen($command, "r"); 
-    while (!feof($fp)) { 
+    $fp = popen($command, "r");
+    while (!feof($fp)) {
       $buffer = fgets($fp, 4096);
       $string .= $buffer;
     }
@@ -1163,23 +1163,23 @@ function output_data_to_external_format($rrdtool_graph_series,
   foreach ($xml->data->row as $objects) {
     $values = get_object_vars($objects);
 
-    // If $values["v"] is an array we have multiple data sources/metrics and 
+    // If $values["v"] is an array we have multiple data sources/metrics and
     // we need to iterate over those
     if (is_array($values["v"])) {
       foreach ($values["v"] as $key => $value) {
-	$output_array[$key]["datapoints"][] = 
+	$output_array[$key]["datapoints"][] =
 	  array(build_value_for_json($value), intval($values['t']));
       }
     } else {
-      $output_array[0]["datapoints"][] = 
+      $output_array[0]["datapoints"][] =
 	array(build_value_for_json($values["v"]), intval($values['t']));
     }
   }
 
   // If JSON output request simple encode the array as JSON
   if ($json_output) {
-    // First let's check if JSON output is requested for 
-    // Live Dashboard and we are outputting aggregate graph. 
+    // First let's check if JSON output is requested for
+    // Live Dashboard and we are outputting aggregate graph.
     // If so we need to add up all the values
     if ($live_dashboard && count($output_array) > 1) {
       $summed_output = array();
@@ -1190,12 +1190,12 @@ function output_data_to_external_format($rrdtool_graph_series,
 	  $summed_output[$index] = array(0, $datapoint[1]);
 	  $output_array_length = count($output_array);
 	  for ($i = 0 ; $i < $output_array_length; $i++) {
-	    $summed_output[$index][0] += 
+	    $summed_output[$index][0] +=
 	      $output_array[$i]['datapoints'][$index][0];
 	  }
 	}
       }
-      
+
       unset($output_array);
       $output_array[0]['datapoints'] = $summed_output;
     }
@@ -1211,10 +1211,10 @@ function output_data_to_external_format($rrdtool_graph_series,
 	$data_array[] = array ($values[1] * 1000, $values[0]);
       }
 
-      $gdata = array('label' => 
-		     strip_domainname($metric_array['host_name']) . 
-		     " " . 
-		     $metric_array['metric_name'], 
+      $gdata = array('label' =>
+		     strip_domainname($metric_array['host_name']) .
+		     " " .
+		     $metric_array['metric_name'],
 		     'data' => $data_array);
 
       if (array_key_exists('color', $metric_array))
@@ -1227,14 +1227,14 @@ function output_data_to_external_format($rrdtool_graph_series,
 	$gdata['lines']['show'] = True;
 	$gdata['lines']['lineWidth'] = 0;
       }
-      
+
       if ($metric_array['graph_type'] == "stack")
 	$gdata['stack'] = '1';
-      
+
       $gdata['graph_title'] = $rrdtool_graph_title;
-      
+
       $flot_array[] = $gdata;
-      
+
       unset($data_array);
     }
     header("Content-type: application/json");
@@ -1244,7 +1244,7 @@ function output_data_to_external_format($rrdtool_graph_series,
   if ($csv_output) {
     header("Content-Type: application/csv");
     header("Content-Disposition: inline; filename=\"ganglia-metrics.csv\"");
-    
+
     print "Timestamp";
 
     // Print out headers
@@ -1253,7 +1253,7 @@ function output_data_to_external_format($rrdtool_graph_series,
     }
 
     print "\n";
-    
+
     foreach ($output_array[0]['datapoints'] as $index => $point) {
       print date("c", $point[1]); // timestamp
       // metric values
@@ -1269,9 +1269,9 @@ function output_data_to_external_format($rrdtool_graph_series,
     header("Content-Type: application/json");
 
     $last_index = count($output_array[0]["datapoints"]) - 1;
-  
-    $output_vals['step'] = 
-      $output_array[0]["datapoints"][1][1] - 
+
+    $output_vals['step'] =
+      $output_array[0]["datapoints"][1][1] -
       $output_array[0]["datapoints"][0][1];
     $output_vals['name'] = "stats." . $output_array[0]["metric_name"];
     $output_vals['start'] = $output_array[0]["datapoints"][0][1];
@@ -1279,8 +1279,8 @@ function output_data_to_external_format($rrdtool_graph_series,
 
     foreach ($output_array[0]["datapoints"] as $array) {
       $output_vals['data'][] = $array[0];
-    } 
-      
+    }
+
     print json_encode(array($output_vals, $output_vals));
   }
 }
@@ -1289,13 +1289,13 @@ function execute_graph_command($graph_engine, $command) {
   global $debug, $user;
 
   // always modified
-  header ("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT"); 
+  header ("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
   header ("Cache-Control: no-cache, must-revalidate"); // HTTP/1.1
   header ("Pragma: no-cache"); // HTTP/1.0
   if ($debug > 2) {
     header ("Content-type: text/html");
     print "<html><body>";
-    
+
     switch ($graph_engine) {
     case "flot":
     case "rrdtool":
@@ -1304,14 +1304,14 @@ function execute_graph_command($graph_engine, $command) {
     case "graphite":
       print $command;
       break;
-    }        
+    }
     print "</body></html>";
   } else {
     if ( $user['image_format'] == "svg" )
       header ("Content-type: image/svg+xml");
     else
       header ("Content-type: image/png");
-    switch ($graph_engine) {  
+    switch ($graph_engine) {
     case "flot":
     case "rrdtool":
       if (strlen($command) < 100000) {
@@ -1326,7 +1326,7 @@ function execute_graph_command($graph_engine, $command) {
     case "graphite":
       echo file_get_contents($command);
       break;
-    }        
+    }
   }
 }
 
@@ -1357,7 +1357,7 @@ $min = isset($_GET["n"]) && is_numeric($_GET["n"]) ? $_GET["n"] : NULL;
 
 $summary = isset($_GET["su"]) ? 1 : 0;
 $debug = isset($_GET['debug']) ? clean_number(sanitize($_GET["debug"])) : 0;
-$user['time_shift'] = isset($_GET["ts"]) ? 
+$user['time_shift'] = isset($_GET["ts"]) ?
   clean_number(sanitize($_GET["ts"])) : 0;
 
 $user['json_output'] = isset($_GET["json"]) ? 1 : NULL;
@@ -1378,32 +1378,32 @@ $user['image_format'] = (isset($_REQUEST["image_format"]) and $_REQUEST["image_f
 
 $user['trend_line'] = isset($_REQUEST["trend"]) ? 1 : NULL;
 // How many months ahead to extend the trend e.g. 6 months
-$user['trend_range'] = 
-  isset($_GET["trendrange"]) && is_numeric($_GET["trendrange"]) ? 
+$user['trend_range'] =
+  isset($_GET["trendrange"]) && is_numeric($_GET["trendrange"]) ?
   $_GET["trendrange"] : 6;
 
-$user['trend_history'] = 
-  isset($_GET["trendhistory"]) && is_numeric($_GET["trendhistory"]) ? 
+$user['trend_history'] =
+  isset($_GET["trendhistory"]) && is_numeric($_GET["trendhistory"]) ?
   $_GET["trendhistory"] : 6;
 
 // Get hostname
-$raw_host = isset($_GET["h"]) ? sanitize($_GET["h"]) : "__SummaryInfo__";  
+$raw_host = isset($_GET["h"]) ? sanitize($_GET["h"]) : "__SummaryInfo__";
 
 // For graphite purposes we need to replace all dots with underscore.
 // dot separates subtrees in graphite
 $graphite_host = str_replace(".", "_", $raw_host);
 
-$size = 
-  isset($_GET["z"]) && 
-  in_array($_GET['z'], $conf['graph_sizes_keys']) ? 
+$size =
+  isset($_GET["z"]) &&
+  in_array($_GET['z'], $conf['graph_sizes_keys']) ?
   $_GET["z"] : 'default';
 
-if (isset($_GET['height']) && is_numeric($_GET['height'])) 
+if (isset($_GET['height']) && is_numeric($_GET['height']))
   $height = $_GET['height'];
-else 
+else
   $height  = $conf['graph_sizes'][$size]['height'];
 
-if (isset($_GET['width']) && is_numeric($_GET['width'])) 
+if (isset($_GET['width']) && is_numeric($_GET['width']))
   $width =  $_GET['width'];
 else
   $width = $conf['graph_sizes'][$size]['width'];
@@ -1460,7 +1460,7 @@ $resource = GangliaAcl::ALL_CLUSTERS;
 if ($context == "grid") {
   $resource = $grid;
 } else if ($context == "cluster" || $context == "host") {
-  $resource = $user['clustername']; 
+  $resource = $user['clustername'];
 }
 
 if (! checkAccess($resource, GangliaAcl::VIEW, $conf)) {
@@ -1489,7 +1489,7 @@ $rrdtool_graph = array('start' => $start,
 if ($size == "small")
   $conf['strip_domainname'] = TRUE;
 
-$load_color = isset($_GET["l"]) && 
+$load_color = isset($_GET["l"]) &&
   is_valid_hex_color(rawurldecode($_GET['l'])) ?
   sanitize($_GET["l"]) : NULL;
 if (! isset($subtitle) && $load_color)
@@ -1498,42 +1498,42 @@ if (! isset($subtitle) && $load_color)
 if ($debug)
   error_log("Graph [$graph] in context [$context]");
 
-/* 
-   If we have $graph, then a specific report was requested, such as 
-   "network_report" or "cpu_report.  These graphs usually have some 
-   special logic and custom handling required, instead of simply 
+/*
+   If we have $graph, then a specific report was requested, such as
+   "network_report" or "cpu_report.  These graphs usually have some
+   special logic and custom handling required, instead of simply
    plotting a single metric.  If $graph is not set, then we are (hopefully),
    plotting a single metric, and will use the commands in the metric.php file.
 
-   With modular graphs, we look for a "${graph}.php" file, and if it 
-   exists, we source it, and call a pre-defined function name.  
-   The current scheme for the function names is:   'graph_' + 
+   With modular graphs, we look for a "${graph}.php" file, and if it
+   exists, we source it, and call a pre-defined function name.
+   The current scheme for the function names is:   'graph_' +
    <name_of_report>.  So a 'cpu_report' would call graph_cpu_report(),
    which would be found in the cpu_report.php file.
 
-   These functions take the $rrdtool_graph array as an argument.  
-   This variable is PASSED BY REFERENCE, and will be modified by the 
-   various functions.  Each key/value pair represents an option/argument, 
-   as passed to the rrdtool program.  Thus, $rrdtool_graph['title'] 
+   These functions take the $rrdtool_graph array as an argument.
+   This variable is PASSED BY REFERENCE, and will be modified by the
+   various functions.  Each key/value pair represents an option/argument,
+   as passed to the rrdtool program.  Thus, $rrdtool_graph['title']
    will refer to the --title option for rrdtool, and pass the array
    value accordingly.
-   
-   There are two exceptions to:  the 'extras' and 'series' keys in 
-   $rrdtool_graph.  These are assigned to $extras and $series 
+
+   There are two exceptions to:  the 'extras' and 'series' keys in
+   $rrdtool_graph.  These are assigned to $extras and $series
    respectively, and are treated specially.  $series will contain
-   the various DEF, CDEF, RULE, LINE, AREA, etc statements that 
-   actually plot the charts.  The rrdtool program requires that 
+   the various DEF, CDEF, RULE, LINE, AREA, etc statements that
+   actually plot the charts.  The rrdtool program requires that
    this come *last* in the argument string; we make sure that it
-   is put in it's proper place.  The $extras variable is used 
-   for other arguemnts that may not fit nicely for other reasons.  
+   is put in it's proper place.  The $extras variable is used
+   for other arguemnts that may not fit nicely for other reasons.
    Complicated requests for --color, or adding --ridgid, for example.
-   It is simply a way for the graph writer to add an arbitrary 
-   options when calling rrdtool, and to forcibly override other 
-   settings, since rrdtool will use the last version of an 
-   option passed. (For example, if you call 'rrdtool' with 
+   It is simply a way for the graph writer to add an arbitrary
+   options when calling rrdtool, and to forcibly override other
+   settings, since rrdtool will use the last version of an
+   option passed. (For example, if you call 'rrdtool' with
    two --title statements, the second one will be used.)
-   
-   See ${conf['graphdir']}/sample.php for more documentation, and 
+
+   See ${conf['graphdir']}/sample.php for more documentation, and
    details on the common variables passed and used.
  */
 
@@ -1558,7 +1558,7 @@ if (isset($_GET["aggregate"]) && $_GET['aggregate'] == 1) {
 
   $graph_config = build_aggregate_graph_config_from_url($conf['graph_colors']);
 
-  // Reset graph title 
+  // Reset graph title
   $title = (isset($_GET['title']) && $_GET['title'] != "") ? "" : "Aggregate";
 }
 
@@ -1568,7 +1568,7 @@ if (isset($_GET["aggregate"]) && $_GET['aggregate'] == 1) {
 $user['view_name'] = isset($_GET["vn"]) ? sanitize ($_GET["vn"]) : NULL;
 $user['item_id'] = isset($_GET["item_id"]) ? sanitize ($_GET["item_id"]) : NULL;
 if ($user['view_name'] && $user['item_id']) {
-  list ($rrdtool_graph, $graph_config) = 
+  list ($rrdtool_graph, $graph_config) =
     rrdtool_graph_build_view_graph($rrdtool_graph,
 				   $user['view_name'],
 				   $user['item_id'],
@@ -1578,9 +1578,9 @@ if ($user['view_name'] && $user['item_id']) {
 				   $conf['graphreport_stats'],
 				   $conf['graphreport_stat_items']);
   # Reset title
-  $title ="";			   
+  $title ="";
 }
-				   
+
 //////////////////////////////////////////////////////////////////////////////
 // Build graph execution command based graph engine
 //////////////////////////////////////////////////////////////////////////////
@@ -1596,7 +1596,7 @@ switch ($conf['graph_engine']) {
       if (is_file($php_report_file) &&
 	  (dirname(realpath($php_report_file)) ==  $conf['graphdir'])) {
 	if (($graph == "metric") &&
-	    isset($_GET['title']) && 
+	    isset($_GET['title']) &&
 	    $_GET['title'] !== '')
 	  $metrictitle = sanitize($_GET['title']);
 	include_once $php_report_file;
@@ -1622,11 +1622,11 @@ switch ($conf['graph_engine']) {
 					    $context,
 					    $grid,
 					    $raw_host,
-					    $graph, 
+					    $graph,
 					    $graph_arguments);
     break;
 
-    case "graphite": 
+    case "graphite":
     $graphite_url = build_graphite_url($rrd_graphite_link,
 				       $rrd_dir,
 				       $conf,
@@ -1647,18 +1647,18 @@ switch ($conf['graph_engine']) {
 				       $title,
 				       $range);
     break;
-} 
+}
 
 // Output graph data to external formats
-if ($user['json_output'] || 
-    $user['csv_output'] || 
-    $user['flot_output'] || 
+if ($user['json_output'] ||
+    $user['csv_output'] ||
+    $user['flot_output'] ||
     $user['graphlot_output']) {
   if ($conf['graph_engine'] == "graphite") {
-    if ($user['json_output'] == 1) { 
-      $output_format = "json"; 
+    if ($user['json_output'] == 1) {
+      $output_format = "json";
     } elseif ($user['csv_output'] == 1) {
-      $output_format = "csv"; 
+      $output_format = "csv";
     }
     echo file_get_contents($graphite_url . "&format=" . $output_format);
   } else {
@@ -1683,17 +1683,17 @@ if ($user['json_output'] ||
 //////////////////////////////////////////////////////////////////////////////
 $showEvents = isset($_GET["event"]) ? sanitize ($_GET["event"]) : "show";
 if ($showEvents == "show" &&
-    $conf['overlay_events'] && 
-    $conf['graph_engine'] == "rrdtool" && 
-    ! in_array($range, $conf['overlay_events_exclude_ranges']) && 
+    $conf['overlay_events'] &&
+    $conf['graph_engine'] == "rrdtool" &&
+    ! in_array($range, $conf['overlay_events_exclude_ranges']) &&
     ! $user['trend_line']) {
   $nagios_events = array();
   if ($conf['overlay_nagios_events'])
-    $nagios_events = get_nagios_events($conf['overlay_nagios_base_url'], 
+    $nagios_events = get_nagios_events($conf['overlay_nagios_base_url'],
 				       $raw_host,
 				       $start,
 				       $end);
-  $command = 
+  $command =
     rrdgraph_cmd_add_overlay_events($command,
 				    $rrdtool_graph['start'],
 				    $rrdtool_graph['end'],
@@ -1717,32 +1717,32 @@ if ($user['trend_line']) {
 // Timeshift is only available to metric graphs
 ////////////////////////////////////////////////////////////////////////////////
 if ($user['time_shift'] && $graph == "metric") {
-  preg_match_all("/(DEF|CDEF):((([^ \"'])+)|(\"[^\"]*\")|('[^']*'))+/", 
-                 " " . $rrdtool_graph['series'], 
+  preg_match_all("/(DEF|CDEF):((([^ \"'])+)|(\"[^\"]*\")|('[^']*'))+/",
+                 " " . $rrdtool_graph['series'],
                  $matches);
 
   // Only do this for metric graphs
   $start = intval(abs(str_replace("s", "", $rrdtool_graph['start'])));
   $offset = 2 * $start;
-  
-  $def = str_replace("DEF:'sum'", "DEF:'sum2'", trim($matches[0][0])) . 
+
+  $def = str_replace("DEF:'sum'", "DEF:'sum2'", trim($matches[0][0])) .
     ":start=end-" . $offset;
-  
+
   $command .= " " . $def . " SHIFT:sum2:" . $start;
-  $command .= " 'LINE2:sum2" . $conf['timeshift_line_color'] . 
+  $command .= " 'LINE2:sum2" . $conf['timeshift_line_color'] .
     ":Previous " . $range . ":dashes'";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Add warning and critical lines
 ////////////////////////////////////////////////////////////////////////////////
-$warning = isset($_GET["warn"]) && is_numeric($_GET["warn"]) ? 
+$warning = isset($_GET["warn"]) && is_numeric($_GET["warn"]) ?
   $_GET["warn"] : NULL;
 if ($warning) {
-  $command .= " 'HRULE:" . $warning . "#FFF600:Warning:dashes'";  
+  $command .= " 'HRULE:" . $warning . "#FFF600:Warning:dashes'";
 }
 
-$critical = isset($_GET["crit"]) && is_numeric($_GET["crit"]) ? 
+$critical = isset($_GET["crit"]) && is_numeric($_GET["crit"]) ?
   $_GET["crit"] : NULL;
 if ($critical) {
   $command .= " 'HRULE:" . $critical . "#FF0000:Critical:dashes'";
@@ -1762,7 +1762,7 @@ if ($debug) {
 # Did we generate a command? Run it.
 if ($command || $graphite_url)
   execute_graph_command($conf['graph_engine'],
-			($conf['graph_engine'] == "graphite") ? 
+			($conf['graph_engine'] == "graphite") ?
 			$graphite_url : $command);
 
 ?>

--- a/graph_all_periods.php
+++ b/graph_all_periods.php
@@ -12,6 +12,7 @@ $data->assign("embed",
               isset($_REQUEST['embed']) ? $_REQUEST['embed'] : NULL);
 $data->assign("mobile",
               isset($_REQUEST['mobile']) ? $_REQUEST['mobile'] : NULL);
+$data->assign("h", isset($_GET['h']) ? $_GET['h'] : NULL);
 $data->assign("g", isset($_GET['g']) ? $_GET['g'] : NULL);
 $data->assign("m", isset($_GET['m']) ? $_GET['m'] : NULL);
 $data->assign("html_g",
@@ -46,35 +47,52 @@ $query_string = join("&amp;", $query_string_array);
 $data->assign("query_string", $query_string);
 
 // Descriptive host/aggregate graph
-if (isset($_GET['h']) && ($_GET['h'] != ''))
-  $description = htmlspecialchars($_GET['h']);
-else if (isset($_GET['c']) && ($_GET['c'] != ''))
-  $description = htmlspecialchars($_GET['c']);
-else if (isset($_GET['hreg']) && is_array($_GET['hreg']))
-  $description = htmlspecialchars(join(",", $_GET['hreg']));
-else
-  $description = "Unknown";
+if (isset($_GET['h']) && ($_GET['h'] != '')) {
+  $host_description = htmlspecialchars($_GET['h']);
+  $host_type = "Host name";
+} else if (isset($_GET['c']) && ($_GET['c'] != '')) {
+  $host_description = htmlspecialchars($_GET['c']);
+  $host_type = "Cluster";
+} else if (isset($_GET['hreg']) && is_array($_GET['hreg'])) {
+  $host_description = htmlspecialchars(join(",", $_GET['hreg']));
+  $host_type = "Host name regular expression";
+} else {
+  $host_description = "Unknown";
+  $host_type = "Unknown host type";
+}
 
-$data->assign("description", $description);
+$data->assign("host_type", $host_type);
+$data->assign("host_description", $host_description);
 
-if (isset($_GET['g']))
+if (isset($_GET['g'])) {
   $metric_description = htmlspecialchars($_GET['g']);
-else if ( isset($_GET['m'] ))
+  $metric_type = "Graph";
+} else if ( isset($_GET['m'] )) {
   $metric_description = htmlspecialchars($_GET['m']);
-else if (isset($_GET['mreg']) && is_array($_GET['mreg']) )
+  $metric_type = "Metric";
+} else if (isset($_GET['mreg']) && is_array($_GET['mreg'])) {
   $metric_description = htmlspecialchars(join(",", $_GET['mreg']));
-else
+  $metric_type = "Metric regular expression";
+} else {
   $metric_description = "Unknown";
+  $metric_type = "Unknown metric type";
+}
 
+$data->assign("metric_type", $metric_type);
 $data->assign("metric_description", $metric_description);
 
-# Determine if it's aggregate graph
+# Determine if this is a standalone page launched from the aggregate
+# graph tab
 $is_aggregate = preg_match("/aggregate=1/", $query_string) ? TRUE : FALSE;
+$data->assign("is_aggregate", $is_aggregate);
 
-$graph_actions = array();
-$graph_actions['timeshift'] = !$is_aggregate && !isset($_GET['g']);
-$graph_actions['metric_actions'] = $is_aggregate;
-$graph_actions['decompose'] = $is_aggregate;
+$graph_actions = NULL;
+if (!isset($_REQUEST['mobile'])) {
+  $graph_actions = array();
+  $graph_actions['timeshift'] = !$is_aggregate && !isset($_GET['g']);
+  $graph_actions['metric_actions'] = TRUE;
+  $graph_actions['decompose'] = $is_aggregate;
+}
 $data->assign('graph_actions', $graph_actions);
 
 $data->assign('GRAPH_BASE_ID', $GRAPH_BASE_ID);

--- a/inspect_graph.php
+++ b/inspect_graph.php
@@ -108,7 +108,7 @@ $(function () {
 
   selectSeries = graphControls.find("#select_series");
   selectSeries.multiselect({
-    height: 250,
+    height: "auto",
     position : {
       my: "right bottom",
       at: "left top"
@@ -240,6 +240,7 @@ $(function () {
     selectSeries.multiselect('refresh');
 
     if (first_time) {
+      $("#popup-dialog-navigation").html("");
       var gopt = stacked ? selectStack : selectLine;
       gopt.attr("checked", "checked");
       gopt.button("refresh");

--- a/js/ganglia.js
+++ b/js/ganglia.js
@@ -1,4 +1,4 @@
-$(function(){
+$(function() {
   // Ensure that the window has a unique name
   if ((window.name == null) || window.name == "") {
     var d = new Date();
@@ -25,22 +25,24 @@ $(function(){
       search_field_q.val(search_value);
   }
 
-  });
+});
 
 function selectTab(tab_index) {
   $("#tabs").tabs("select", tab_index);
 }
 
 function addItemToView() {
-  $.get('views_view.php', 
-        $("#add_metric_to_view_form").serialize() + "&add_to_view=1", 
-        function(data) {$("#metric-actions-dialog-content").html(data);});
-  return false;  
+  $.get('views_view.php',
+        $("#add_metric_to_view_form").serialize() + "&add_to_view=1",
+        function(data) {
+          $("#metric-actions-dialog-content").html(data);
+        });
+  return false;
 }
 
 function initMetricActionsDialog() {
   var metric_actions_dialog = $("#metric-actions-dialog");
-  if (metric_actions_dialog[0]) 
+  if (metric_actions_dialog[0])
     metric_actions_dialog.dialog({autoOpen: false,
 		                  width: "auto",
 		                  modal: true,
@@ -50,37 +52,43 @@ function initMetricActionsDialog() {
 }
 
 function metricActions(host_name, metric_name, type, graphargs) {
-    $("#metric-actions-dialog").dialog("open");
-    $("#metric-actions-dialog-content").html('<img src="img/spinner.gif">');
-    $.get('actions.php',
-          "action=show_views&host_name=" + host_name + 
-	  "&metric_name=" + metric_name + 
-	  "&type=" + type + graphargs, 
-          function(data) {$("#metric-actions-dialog-content").html(data);});
-    return false;
+  $("#metric-actions-dialog").dialog("option", "title", "Add To View");
+  $("#metric-actions-dialog").dialog("open");
+  $("#metric-actions-dialog-content").html('<img src="img/spinner.gif">');
+  $.get('actions.php',
+        "action=show_views&host_name=" + host_name +
+	"&metric_name=" + metric_name +
+	"&type=" + type + "&" + graphargs,
+        function(data) {
+          $("#metric-actions-dialog-content").html(data);
+        });
+  return false;
 }
 
 function metricActionsAggregateGraph(args) {
+  $("#metric-actions-dialog").dialog("option", "title", "Add To View");
   $("#metric-actions-dialog").dialog("open");
   $("#metric-actions-dialog-content").html('<img src="img/spinner.gif" />');
-  $.get('actions.php', 
-        "action=show_views" + args + "&aggregate=1", 
-        function(data) {$("#metric-actions-dialog-content").html(data);});
-    return false;
+  $.get('actions.php',
+        "action=show_views&" + args + "&aggregate=1",
+        function(data) {
+          $("#metric-actions-dialog-content").html(data);
+        });
+  return false;
 }
 
 
 function autoRotationChooser() {
   $("#tabs-autorotation-chooser").html('<img src="img/spinner.gif">');
-  $.get('autorotation.php', 
-        "", 
+  $.get('autorotation.php',
+        "",
         function(data) {$("#tabs-autorotation-chooser").html(data);});
 }
 
 function liveDashboardChooser() {
   $("#tabs-livedashboard-chooser").html('<img src="img/spinner.gif">');
-  $.get('tasseo.php', 
-        "", 
+  $.get('tasseo.php',
+        "",
         function(data) {$("#tabs-livedashboard-chooser").html(data);});
 }
 
@@ -100,11 +108,11 @@ function ganglia_submit(clearonly) {
 -----------------------------------------------------------------------------*/
 function inspectGraph(graphArgs) {
   $("#popup-dialog").dialog('open');
-  $("#popup-dialog").bind("dialogbeforeclose", 
-                                  function(event, ui) {
-                                    $("#enlargeTooltip").remove();});
+  $("#popup-dialog").bind("dialogbeforeclose",
+                          function(event, ui) {
+                            $("#enlargeTooltip").remove();});
   $.get('inspect_graph.php',
-        "flot=1&" + graphArgs, 
+        "flot=1&" + graphArgs,
         function(data) {$('#popup-dialog-content').html(data);});
 }
 
@@ -113,12 +121,12 @@ function inspectGraph(graphArgs) {
 -----------------------------------------------------------------------------*/
 function drawTrendGraph(url) {
   $("#popup-dialog").dialog('open');
-  $("#popup-dialog").bind("dialogbeforeclose", 
+  $("#popup-dialog").bind("dialogbeforeclose",
                                   function(event, ui) {
                                     $("#enlargeTooltip").remove();});
   $.get('trend_navigation.php',
         url,
-        function(data) {$('#popup-dialog-navigation').html(data);})
+        function(data) {$('#popup-dialog-navigation').html(data);});
 
   $("#popup-dialog-content").html('<img src="' + url + '" />');
 
@@ -151,7 +159,7 @@ function initTimeShift() {
     $(this).prop("checked", false);
     $(this).button('refresh');
   });
-    
+
   if ($("#timeshift_overlay").length > 0) {
     $("#timeshift_overlay").button();
     $("#timeshift_overlay").prop("checked", false);
@@ -163,7 +171,7 @@ function showTimeshiftOverlay(show) {
   $("[id^=" + TIME_SHIFT_BASE_ID + "]").each(function() {
       $(this).prop('checked', show);
       $(this).button('refresh');
-      var graphId = GRAPH_BASE_ID + 
+      var graphId = GRAPH_BASE_ID +
 	$(this).attr('id').slice(TIME_SHIFT_BASE_ID_LEN);
       showTimeShift(graphId, show);
     });
@@ -171,37 +179,37 @@ function showTimeshiftOverlay(show) {
 
 function showAllEvents(show) {
   $("[id^=" + SHOW_EVENTS_BASE_ID + "]").each(function() {
-      $(this).prop('checked', show);
-      $(this).button('refresh');
-      var graphId = GRAPH_BASE_ID + 
-	$(this).attr('id').slice(SHOW_EVENTS_BASE_ID_LEN);
-      showEvents(graphId, show);
-    });
+    $(this).prop('checked', show);
+    $(this).button('refresh');
+    var graphId = GRAPH_BASE_ID +
+	  $(this).attr('id').slice(SHOW_EVENTS_BASE_ID_LEN);
+    showEvents(graphId, show);
+  });
 }
 
 function showEvents(graphId, show) {
-    var graph = $("#" + graphId);
-    var src = graph.attr("src");
-    if ((src.indexOf("graph.php") != 0) &&
-        (src.indexOf("./graph.php") != 0))
-      return;
-    var paramStr = "&event=";
-    paramStr += show ? "show" : "hide"
-    var d = new Date();
-    paramStr += "&_=" + d.getTime();
-    src = jQuery.param.querystring(src, paramStr);
-    graph.attr("src", src);
-  }
+  var graph = $("#" + graphId);
+  var src = graph.attr("src");
+  if ((src.indexOf("graph.php") != 0) &&
+      (src.indexOf("./graph.php") != 0))
+    return;
+  var paramStr = "&event=";
+  paramStr += show ? "show" : "hide";
+  var d = new Date();
+  paramStr += "&_=" + d.getTime();
+  src = jQuery.param.querystring(src, paramStr);
+  graph.attr("src", src);
+}
 
 function showTimeShift(graphId, show) {
-    var graph = $("#" + graphId);
-    var src = graph.attr("src");
-    if ((src.indexOf("graph.php") != 0) &&
-        (src.indexOf("./graph.php") != 0))
-      return;
-    var paramStr = show ? "&ts=1" : "&ts=0";
-    var d = new Date();
-    paramStr += "&_=" + d.getTime();
-    src = jQuery.param.querystring(src, paramStr);
-    graph.attr("src", src);
-  }
+  var graph = $("#" + graphId);
+  var src = graph.attr("src");
+  if ((src.indexOf("graph.php") != 0) &&
+      (src.indexOf("./graph.php") != 0))
+    return;
+  var paramStr = show ? "&ts=1" : "&ts=0";
+  var d = new Date();
+  paramStr += "&_=" + d.getTime();
+  src = jQuery.param.querystring(src, paramStr);
+  graph.attr("src", src);
+}

--- a/templates/default/graph_all_periods.tpl
+++ b/templates/default/graph_all_periods.tpl
@@ -1,8 +1,8 @@
 {if $standalone}
-<html>
-  <head>
-    <title>Ganglia: Graph all periods</title>
-    {include('scripts.tpl')}
+  <html>
+    <head>
+      <title>Ganglia: Graph all periods</title>
+      {include('scripts.tpl')}
 {/if}
 <script type="text/javascript">
  function openDecompose($url) {
@@ -11,16 +11,22 @@
  }
 
  $(function() {
+   {if isset($graph_actions)}
    initShowEvent();
+   {if $graph_actions['timeshift']}
    initTimeShift();
-   {if $standalone}
+   {/if}
+   {if $graph_actions['metric_actions'] && $standalone}
    initMetricActionsDialog();
+   {/if}
+   {if $standalone}
    $("#popup-dialog").dialog( { autoOpen: false,
                                 width:800,
                                 height:500,
                                 position: { my: "top",
                                             at: "top+200",
                                             of: window } } );
+   {/if}
    {/if}
  });
 </script>
@@ -35,132 +41,154 @@
 
   <script type="text/javascript">
    var metric = "{if isset($g)} {$g} {else} {$m} {/if}";
-   var base_url = "graph.php?flot=1&amp;{$m}{$query_string}&amp;r=hour";
+   var base_url = "graph.php?flot=1&amp;{$m}&amp;{$query_string}&amp;r=hour";
   </script>
   <script type="text/javascript" src="js/create-flot-graphs.js"></script>
 {/if}
 
 {if $standalone}
-  </head>
-  <body onSubmit="return false;">
+    </head>
+    <body onSubmit="return false;">
 
-    <div id="popup-dialog" title="Inspect Graph">
-      <div id="popup-dialog-navigation"></div>
-      <div id="popup-dialog-content">
+      <div id="popup-dialog" title="Inspect Graph">
+        <div id="popup-dialog-navigation"></div>
+        <div id="popup-dialog-content">
+        </div>
       </div>
-    </div>
 
-    <div id="metric-actions-dialog" style="display: none" title="Metric Actions">
-      <div id="metric-actions-dialog-content">
-        Available Metric actions.
+      <div id="metric-actions-dialog"
+           style="display: none"
+           title="Metric Actions">
+        <div id="metric-actions-dialog-content">
+          Available Metric actions.
+        </div>
       </div>
-    </div>
 {/if}
 
 <form>
-{if isset($mobile)}
-  <div data-role="page" class="ganglia-mobile" id="view-home">
-    <div data-role="header">
-      <a href="#" class="ui-btn-left" data-icon="arrow-l" onclick="history.back(); return false">Back</a>
-      <h3>{if isset($html_g)} {$html_g} {else} {$html_m} {/if}</h3>
-      <a href="#mobile-home">Home</a>
-    </div>
-    <div data-role="content">
-{/if}
 
-{if !isset($embed)}
-  <div><b>Host/Cluster/Host Regex: </b>{$description}&nbsp;<b>Metric/Graph/Metric Regex: </b>{$metric_description}&nbsp;&nbsp;
-{/if}
-
-{if !isset($mobile)}
-  <input title="Hide/Show Events"
-         type="checkbox"
-         id="show_all_events"
-         onclick="showAllEvents(this.checked)"/>
-  <label class="show_event_text" for="show_all_events">Hide/Show Events All Graphs</label>
-  {if $graph_actions['timeshift']}
-    <input title="Timeshift Overlay"
-           type="checkbox"
-           id="timeshift_overlay"
-           onclick="showTimeshiftOverlay(this.checked)"/>
-    <label class="show_timeshift_text" for="timeshift_overlay">Timeshift Overlay</label>
-    <br />
+  {if isset($mobile)}
+    <div data-role="page" class="ganglia-mobile" id="view-home">
+      <div data-role="header">
+        <a href="#" class="ui-btn-left"
+           data-icon="arrow-l"
+           onclick="history.back(); return false">Back</a>
+        <h3>{if isset($html_g)} {$html_g} {else} {$html_m} {/if}</h3>
+        <a href="#mobile-home">Home</a>
+      </div>
+      <div data-role="content">
   {/if}
-  </div>
-{/if}
 
-{if isset($embed)}
-  <div style='height:10px;'/>
-{/if}
+  {if $standalone}
+    <div style="background-color:#dddddd;{if $standalone} padding:5px; {/if}">
+      <big>
+        <b>{$host_type}: </b>{$host_description}&nbsp;
+        <b>{$metric_type}: </b>{$metric_description}&nbsp;&nbsp;
+      </big>
+    </div>
+  {/if}
 
-{foreach $conf['time_ranges'] key value}
-  {if $value != 'job'}
-    <div class="img_view">
-      {$graphId = cat($GRAPH_BASE_ID $key)}
-
-      {if !isset($mobile)}
-        <span style="padding-left: 4em; padding-right: 4em; text-weight: bold;">{$key}</span>
-
-        {if $graph_actions['metric_actions']}
-          <button class="cupid-green"
-                  title="Metric Actions - Add to View, etc"
-                  onclick="metricActionsAggregateGraph('{$query_string}'); return false;">+</button>
-        {/if}
-
-        <button title="Export to CSV"
-                class="cupid-green"
-                onclick="window.location='./graph.php?r={$key}{$query_string}&amp;csv=1';return false">CSV</button>
-
-        <button title="Export to JSON"
-                class="cupid-green"
-                onclick="window.location='./graph.php?r={$key}{$query_string}&amp;json=1';return false;">JSON</button>
-
-        {if $graph_actions['decompose']}
-          <button title="Decompose aggregate graph"
-                  class="shiny-blue"
-                  onClick="openDecompose('?r={$key}{$query_string}&amp;dg=1');return false;">Decompose</button>
-        {/if}
-
-        <button title="Inspect Graph"
-                onClick="inspectGraph('r={$key}{$query_string}'); return false;" class="shiny-blue">Inspect</button>
-
-        {$showEventsId = cat($SHOW_EVENTS_BASE_ID $key)}
-
+  {if isset($graph_actions)}
+    {if $standalone}
+      <div style='height:10px;'></div>
+    {/if}
+    <div>
+      <div style="float:right;">
         <input title="Hide/Show Events"
                type="checkbox"
-               id="{$showEventsId}"
-               onclick="showEvents('{$graphId}', this.checked)"/>
-        <label class="show_event_text" for="{$showEventsId}">Hide/Show Events</label>
-
+               id="show_all_events"
+               onclick="showAllEvents(this.checked)"/>
+        <label class="show_event_text"
+               for="show_all_events">Hide/Show Events All Graphs</label>
         {if $graph_actions['timeshift']}
-          {$timeShiftId = cat($TIME_SHIFT_BASE_ID $key)}
           <input title="Timeshift Overlay"
                  type="checkbox"
-                 id="{$timeShiftId}"
-                 onclick="showTimeShift('{$graphId}', this.checked)"/>
-          <label class="show_timeshift_text" for="{$timeShiftId}">Timeshift</label>
+                 id="timeshift_overlay"
+                 onclick="showTimeshiftOverlay(this.checked)"/>
+          <label class="show_timeshift_text"
+                 for="timeshift_overlay">Timeshift Overlay</label>
+          <br />
         {/if}
-      {/if}
-
-      <br />
-
-      {if $conf['graph_engine'] == "flot"}
-        <div id="placeholder_{$key}" class="flotgraph img_view"></div>
-        <div id="placeholder_{$key}_legend" class="flotlegend"></div>
-      {else}
-        <a href="./graph.php?r={$key}&amp;z={$xlargesize}{$query_string}">
-          <img class="noborder"
-               id="{$graphId}"
-               style="margin-top:5px;"
-               title="Last {$key}"
-               src="graph.php?r={$key}&amp;z={$largesize}{$query_string}"></a>
-      {/if}
+      </div>
+      <div style="clear:both"></div>
     </div>
   {/if}
-{/foreach}
-<div style="clear: left"></div>
+
+  {if isset($embed) || $standalone}
+    <div style='height:10px;'></div>
+  {/if}
+
+  {foreach $conf['time_ranges'] key value}
+    {if $value != 'job'}
+      <div class="img_view">
+        {$graphId = cat($GRAPH_BASE_ID $key)}
+
+        {if isset($graph_actions)}
+          <span style="padding-left: 4em; padding-right: 4em; text-weight: bold;">{$key}</span>
+
+          {if $graph_actions['metric_actions']}
+            <button class="cupid-green"
+                    title="Metric Actions - Add to View, etc"
+                    onclick="{if $is_aggregate} metricActionsAggregateGraph('{$query_string}') {else} metricActions('{$h}', {if isset($g)} '{$g}', 'graph' {else} '{$m}', 'metric' {/if}, '{$query_string}'){/if}; return false;">+</button>
+          {/if}
+
+          <button title="Export to CSV"
+                  class="cupid-green"
+                  onclick="window.location='./graph.php?r={$key}&amp;{$query_string}&amp;csv=1';return false">CSV</button>
+
+          <button title="Export to JSON"
+                  class="cupid-green"
+                  onclick="window.location='./graph.php?r={$key}&amp;{$query_string}&amp;json=1';return false;">JSON</button>
+
+          {if $graph_actions['decompose']}
+            <button title="Decompose aggregate graph"
+                    class="shiny-blue"
+                    onClick="openDecompose('?r={$key}&amp;{$query_string}&amp;dg=1');return false;">Decompose</button>
+          {/if}
+
+          <button title="Inspect Graph"
+                  onClick="inspectGraph('r={$key}&amp;{$query_string}'); return false;"
+                  class="shiny-blue">Inspect</button>
+
+          {$showEventsId = cat($SHOW_EVENTS_BASE_ID $key)}
+
+          <input title="Hide/Show Events"
+                 type="checkbox"
+                 id="{$showEventsId}"
+                 onclick="showEvents('{$graphId}', this.checked)"/>
+          <label class="show_event_text"
+                 for="{$showEventsId}">Hide/Show Events</label>
+
+          {if $graph_actions['timeshift']}
+            {$timeShiftId = cat($TIME_SHIFT_BASE_ID $key)}
+            <input title="Timeshift Overlay"
+                   type="checkbox"
+                   id="{$timeShiftId}"
+                   onclick="showTimeShift('{$graphId}', this.checked)"/>
+            <label class="show_timeshift_text"
+                   for="{$timeShiftId}">Timeshift</label>
+          {/if}
+        {/if}
+
+        <br />
+
+        {if $conf['graph_engine'] == "flot"}
+          <div id="placeholder_{$key}" class="flotgraph img_view"></div>
+          <div id="placeholder_{$key}_legend" class="flotlegend"></div>
+        {else}
+          <a href="./graph.php?r={$key}&amp;z={$xlargesize}&amp;{$query_string}">
+            <img class="noborder"
+                 id="{$graphId}"
+                 style="margin-top:5px;"
+                 title="Last {$key}"
+                 src="graph.php?r={$key}&amp;z={$largesize}&amp;{$query_string}"></a>
+        {/if}
+      </div>
+    {/if}
+  {/foreach}
+  <div style="clear: left"></div>
 </form>
 {if $standalone}
-</body>
-</html>
+    </body>
+  </html>
 {/if}

--- a/templates/default/header.tpl
+++ b/templates/default/header.tpl
@@ -1,372 +1,345 @@
 <!-- Begin header.tpl -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
-<head>
-<title>Ganglia:: {$page_title}</title>
-<meta http-equiv="Content-type" content="text/html; charset=utf-8">
-<link type="text/css" href="{$conf['jqueryui_smoothness_css_path']}" rel="stylesheet" />
-<link type="text/css" href="css/jquery.liveSearch.css" rel="stylesheet" />
-<link type="text/css" href="css/jquery.multiselect.css" rel="stylesheet" />
-<link type="text/css" href="css/jquery.flot.events.css" rel="stylesheet" />
-<link type="text/css" href="{$conf['fullcalendar_css_path']}" rel="stylesheet" />
-<link type="text/css" href="css/qtip.min.css" rel="stylesheet" />
-<link type="text/css" href="{$conf['chosen_css_path']}" rel="stylesheet" />
-<style type="text/css">
-.chosen-container-multi .chosen-choices li.search-field input[type="text"] {
-  height: auto;
-}
-</style>
-<link type="text/css" href="{$conf['select2_css_path']}" rel="stylesheet" />
-<link type="text/css" href="./styles.css" rel="stylesheet" />
-<link type="text/css" href="{$conf['jstree_css_path']}" rel="stylesheet" />
-<script type="text/javascript" src="{$conf['jquery_js_path']}"></script>
-<script>$.uiBackCompat = false;</script>
-<script type="text/javascript" src="{$conf['jqueryui_js_path']}"></script>
-<script type="text/javascript" src="js/jquery.livesearch.min.js"></script>
-<script type="text/javascript" src="js/ganglia.js"></script>
-<script type="text/javascript" src="js/jquery.gangZoom.js"></script>
-<script type="text/javascript" src="{$conf['jquery_cookie_js_path']}"></script>
-<script type="text/javascript" src="js/jquery-ui-timepicker-addon.js"></script>
-<script type="text/javascript" src="js/jquery.ba-bbq.min.js"></script>
-<script type="text/javascript" src="js/combobox.js"></script>
-<script type="text/javascript" src="{$conf['jquery_scrollTo_js_path']}"></script>
-<script type="text/javascript" src="js/jquery.buttonsetv.js"></script>
-<script type="text/javascript" src="{$conf['jstree_js_path']}"></script>
-<script type="text/javascript" src="js/jquery.qtip.min.js"></script>
-<script type="text/javascript" src="{$conf['chosen_js_path']}"></script>
-<script type="text/javascript" src="{$conf['select2_js_path']}"></script>
-<script type="text/javascript" src="{$conf['jstz_js_path']}"></script>
-<script type="text/javascript" src="{$conf['moment_js_path']}"></script>
-<script type="text/javascript" src="{$conf['moment-timezone_js_path']}"></script>
-<script type="text/javascript" src="{$conf['fullcalendar_js_path']}"></script>
-<script type="text/javascript">
- var time_ranges = {$time_ranges};
- var server_timezone='{$server_timezone}';
- var g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
- var tz = jstz.determine();
+  <head>
+    <title>Ganglia:: {$page_title}</title>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    {include('scripts.tpl')}
+    <script type="text/javascript">
+     var time_ranges = {$time_ranges};
+     var server_timezone='{$server_timezone}';
+     var g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+     var tz = jstz.determine();
 
- function refreshHeader() {
-   $.get('header.php?date_only=1', function(datetime) {
-     var pageTitle = $("#page_title");
-     var title = pageTitle.text();
-     var l = title.lastIndexOf(" at ");
-     if (l != -1)
-       title = title.substring(0, l);
-     title += " at " + datetime;
-     pageTitle.text(title);
-   });
- }
-
- function refresh() {
-   var selected_tab = $("#selected_tab").val();
-   if (selected_tab == "agg") {
-     refreshAggregateGraph();
-     g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
-   } else if (selected_tab == "v") {
-     refreshHeader();
-     if ($.isFunction(window.refreshView)) {
-       refreshView();
-       g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
-     } else if ($.isFunction(window.refreshDecomposeGraph)) {
-       refreshDecomposeGraph();
-       g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
-     } else
-     ganglia_form.submit();
-   } else if (selected_tab == "ev") {
-     refreshOverlayEvent();
-     g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
-   } else if (selected_tab == "m") {
-     if ($.isFunction(window.refreshClusterView)) {
-       refreshHeader();
-       refreshClusterView();
-       g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
-     } else if ($.isFunction(window.refreshHostView)) {
-       refreshHeader();
-       refreshHostView();
-       g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
-     } else
-     ganglia_form.submit();
-   } else
-   ganglia_form.submit();
- }
-
- // start and end are momemnts
- function setStartAndEnd(start, end) {
-   // Generate RRD friendly date/time strings
-   $("#datepicker-cs").val(start.format('MM/D/YYYY HH:mm'));
-   $("#datepicker-ce").val(end.format('MM/D/YYYY HH:mm'));
- }
-
- function getCurrentRange() {
-   var range = null;
-   var range_menu = $("#range_menu");
-   if (range_menu[0])
-     range = $("#range_menu :radio:checked + label").text();
-   return range;
- }
- 
- // Return the current time range as a pair of moments
- function getCurrentTimeRange() {
-   var cs = $("#datepicker-cs").val();
-   var ce = $("#datepicker-ce").val();
-   var start = 0;
-   var end = 0;
-   if (getCurrentRange() == "custom" && cs && ce) {
-     if ($("#tz").val() == "") {
-       start = moment.tz(cs, server_timezone);
-       end = moment.tz(ce, server_timezone);
-     } else {
-       start = moment(cs);
-       end = moment(ce);
+     function refreshHeader() {
+       $.get('header.php?date_only=1', function(datetime) {
+         var pageTitle = $("#page_title");
+         var title = pageTitle.text();
+         var l = title.lastIndexOf(" at ");
+         if (l != -1)
+           title = title.substring(0, l);
+         title += " at " + datetime;
+         pageTitle.text(title);
+       });
      }
-   } else {
-     end = ($("#tz").val() == "") ? moment().tz(server_timezone) : moment();
-     var range = getCurrentRange();
-     start = moment(end).subtract(time_ranges["rng_" + range], "s");
-   }
-   return {
-     start: start,
-     end: end};
- }
 
- /* selStart and selEnd are fractions of the current time range */
- gangZoomDone = function done(selStart, selEnd) {
-   var currentRange = getCurrentTimeRange();
-   var span = currentRange.end.unix() - currentRange.start.unix();
-   setStartAndEnd(
-     moment(currentRange.start).add(Math.floor(selStart * span), "s"),
-     moment(currentRange.start).add(Math.floor(selEnd * span), "s"));
-   document.forms['ganglia_form'].submit();
- }
+     function refresh() {
+       var selected_tab = $("#selected_tab").val();
+       if (selected_tab == "agg") {
+         refreshAggregateGraph();
+         g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+       } else if (selected_tab == "s") {
+         // Dont refresh the serach tab
+       } else if (selected_tab == "v") {
+         refreshHeader();
+         if ($.isFunction(window.refreshView)) {
+           refreshView();
+           g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+         } else if ($.isFunction(window.refreshDecomposeGraph)) {
+           refreshDecomposeGraph();
+           g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+         } else
+         ganglia_form.submit();
+       } else if (selected_tab == "ev") {
+         refreshOverlayEvent();
+         g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+       } else if (selected_tab == "m") {
+         if ($.isFunction(window.refreshClusterView)) {
+           refreshHeader();
+           refreshClusterView();
+           g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+         } else if ($.isFunction(window.refreshHostView)) {
+           refreshHeader();
+           refreshHostView();
+           g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+         } else
+         ganglia_form.submit();
+       } else
+       ganglia_form.submit();
+     }
 
- gangZoomCancel = function(selStart, selEnd) {
- }
+     // start and end are momemnts
+     function setStartAndEnd(start, end) {
+       // Generate RRD friendly date/time strings
+       $("#datepicker-cs").val(start.format('MM/D/YYYY HH:mm'));
+       $("#datepicker-ce").val(end.format('MM/D/YYYY HH:mm'));
+     }
 
- g_gangZoomDefaults = {
-   done: gangZoomDone,
-   cancel: gangZoomCancel
- }
+     function getCurrentRange() {
+       var range = null;
+       var range_menu = $("#range_menu");
+       if (range_menu[0])
+         range = $("#range_menu :radio:checked + label").text();
+       return range;
+     }
 
- function initCustomTimeRangeDragSelect(context) {
-   context.find(".host_small_zoomable").gangZoom($.extend({
-     paddingLeft: 67,
-     paddingRight: 30,
-     paddingTop: 38,
-     paddingBottom: 25
-   }, g_gangZoomDefaults));
-
-   context.find(".host_medium_zoomable").gangZoom($.extend({
-     paddingLeft: 67,
-     paddingRight: 30,
-     paddingTop: 38,
-     paddingBottom: 40
-   }, g_gangZoomDefaults));
-   
-   context.find(".host_default_zoomable").gangZoom($.extend({
-     paddingLeft: 66,
-     paddingRight: 30,
-     paddingTop: 37,
-     paddingBottom: 50
-   }, g_gangZoomDefaults));
-   
-   context.find(".host_large_zoomable").gangZoom($.extend({
-     paddingLeft: 66,
-     paddingRight: 29,
-     paddingTop: 37,
-     paddingBottom: 56
-   }, g_gangZoomDefaults));
-
-   context.find(".cluster_zoomable").gangZoom($.extend({
-     paddingLeft: 67,
-     paddingRight: 30,
-     paddingTop: 37,
-     paddingBottom: 50
-   }, g_gangZoomDefaults));
- }
-
- $(function() {
-   var range_menu = $("#range_menu");
-   if (range_menu[0])
-     range_menu.buttonset();
-
-   var custom_range_menu = $("#custom_range_menu");
-   if (custom_range_menu[0])
-     custom_range_menu.buttonset();
-
-   var sort_menu = $("#sort_menu");
-   if (sort_menu[0])
-     sort_menu.buttonset();
-
-   g_overlay_events = ($("#overlay_events").val() == "true");
-   
-   g_tabIndex = new Object();
-   g_tabName = [];
-   var tabName = ["m", "s", "v", "agg", "ch", "ev", "rep", "rot", "lvd", "cub", "mob"];
-   var j = 0;
-   for (var i in tabName) {
-     if (tabName[i] == "ev" && !g_overlay_events)
-       continue;
-     g_tabIndex[tabName[i]] = j++;
-     g_tabName.push(tabName[i]);
-   }
-
-   // Follow tab's URL instead of loading its content via ajax
-   var tabs = $("#tabs");
-   if (tabs[0]) {
-     tabs.tabs();
-     // Restore previously selected tab
-     var selected_tab = $("#selected_tab").val();
-     //alert("selected_tab = " + selected_tab);
-     if (typeof g_tabIndex[selected_tab] != 'undefined') {
-       try {
-         //alert("Selecting tab: " + selected_tab);
-         tabs.tabs('option', 'active', g_tabIndex[selected_tab]);
-         if (selected_tab == "rot")
-           autoRotationChooser();
-       } catch (err) {
-         try {
-           alert("Error(ganglia.js): Unable to select tab: " + 
-                 selected_tab + ". " + err.getDescription());
-         } catch (err) {
-           // If we can't even show the error, fail silently.
+     // Return the current time range as a pair of moments
+     function getCurrentTimeRange() {
+       var cs = $("#datepicker-cs").val();
+       var ce = $("#datepicker-ce").val();
+       var start = 0;
+       var end = 0;
+       if (getCurrentRange() == "custom" && cs && ce) {
+         if ($("#tz").val() == "") {
+           start = moment.tz(cs, server_timezone);
+           end = moment.tz(ce, server_timezone);
+         } else {
+           start = moment(cs);
+           end = moment(ce);
          }
+       } else {
+         end = ($("#tz").val() == "") ? moment().tz(server_timezone) : moment();
+         var range = getCurrentRange();
+         start = moment(end).subtract(time_ranges["rng_" + range], "s");
        }
+       return {
+         start: start,
+         end: end};
      }
-     tabs.tabs({
-       beforeActivate: function(event, ui) {
-	 var tabIndex = ui.newTab.index();
-	 $("#selected_tab").val(g_tabName[tabIndex]);
-         if (g_tabName[tabIndex] != "mob")
-           $.cookie("ganglia-selected-tab-" + window.name, tabIndex);
-         if (tabIndex == g_tabIndex["m"] ||
-             tabIndex == g_tabIndex["v"] ||
-             tabIndex == g_tabIndex["ch"])
-           ganglia_form.submit();
+
+     /* selStart and selEnd are fractions of the current time range */
+     gangZoomDone = function done(selStart, selEnd) {
+       var currentRange = getCurrentTimeRange();
+       var span = currentRange.end.unix() - currentRange.start.unix();
+       setStartAndEnd(
+         moment(currentRange.start).add(Math.floor(selStart * span), "s"),
+         moment(currentRange.start).add(Math.floor(selEnd * span), "s"));
+       document.forms['ganglia_form'].submit();
+     }
+
+     gangZoomCancel = function(selStart, selEnd) {
+     }
+
+     g_gangZoomDefaults = {
+       done: gangZoomDone,
+       cancel: gangZoomCancel
+     }
+
+     function initCustomTimeRangeDragSelect(context) {
+       context.find(".host_small_zoomable").gangZoom($.extend({
+         paddingLeft: 67,
+         paddingRight: 30,
+         paddingTop: 38,
+         paddingBottom: 25
+       }, g_gangZoomDefaults));
+
+       context.find(".host_medium_zoomable").gangZoom($.extend({
+         paddingLeft: 67,
+         paddingRight: 30,
+         paddingTop: 38,
+         paddingBottom: 40
+       }, g_gangZoomDefaults));
+
+       context.find(".host_default_zoomable").gangZoom($.extend({
+         paddingLeft: 66,
+         paddingRight: 30,
+         paddingTop: 37,
+         paddingBottom: 50
+       }, g_gangZoomDefaults));
+
+       context.find(".host_large_zoomable").gangZoom($.extend({
+         paddingLeft: 66,
+         paddingRight: 29,
+         paddingTop: 37,
+         paddingBottom: 56
+       }, g_gangZoomDefaults));
+
+       context.find(".cluster_zoomable").gangZoom($.extend({
+         paddingLeft: 67,
+         paddingRight: 30,
+         paddingTop: 37,
+         paddingBottom: 50
+       }, g_gangZoomDefaults));
+     }
+
+     $(function() {
+       var range_menu = $("#range_menu");
+       if (range_menu[0])
+         range_menu.buttonset();
+
+       var custom_range_menu = $("#custom_range_menu");
+       if (custom_range_menu[0])
+         custom_range_menu.buttonset();
+
+       var sort_menu = $("#sort_menu");
+       if (sort_menu[0])
+         sort_menu.buttonset();
+
+       g_overlay_events = ($("#overlay_events").val() == "true");
+
+       g_tabIndex = new Object();
+       g_tabName = [];
+       var tabName = ["m", "s", "v", "agg", "ch", "ev", "rep", "rot", "lvd", "cub", "mob"];
+       var j = 0;
+       for (var i in tabName) {
+         if (tabName[i] == "ev" && !g_overlay_events)
+           continue;
+         g_tabIndex[tabName[i]] = j++;
+         g_tabName.push(tabName[i]);
+       }
+
+       // Follow tab's URL instead of loading its content via ajax
+       var tabs = $("#tabs");
+       if (tabs[0]) {
+         tabs.tabs();
+         // Restore previously selected tab
+         var selected_tab = $("#selected_tab").val();
+         //alert("selected_tab = " + selected_tab);
+         if (typeof g_tabIndex[selected_tab] != 'undefined') {
+           try {
+             //alert("Selecting tab: " + selected_tab);
+             tabs.tabs('option', 'active', g_tabIndex[selected_tab]);
+             if (selected_tab == "rot")
+               autoRotationChooser();
+           } catch (err) {
+             try {
+               alert("Error(ganglia.js): Unable to select tab: " +
+                     selected_tab + ". " + err.getDescription());
+             } catch (err) {
+               // If we can't even show the error, fail silently.
+             }
+           }
+         }
+         tabs.tabs({
+           beforeActivate: function(event, ui) {
+	     var tabIndex = ui.newTab.index();
+	     $("#selected_tab").val(g_tabName[tabIndex]);
+             if (g_tabName[tabIndex] != "mob")
+               $.cookie("ganglia-selected-tab-" + window.name, tabIndex);
+             if (tabIndex == g_tabIndex["m"] ||
+                 tabIndex == g_tabIndex["v"] ||
+                 tabIndex == g_tabIndex["ch"])
+               ganglia_form.submit();
+           }
+         });
        }
      });
-   }
- });
 
- $(function () {
-   $("#metrics-picker").val("{$metric_name}");
-   $(".header_btn").button();
+     $(function () {
+       $("#metrics-picker").val("{$metric_name}");
+       $(".header_btn").button();
 
-   initCustomTimeRangeDragSelect($(document.documentElement));
+       initCustomTimeRangeDragSelect($(document.documentElement));
 
-   var tzPicker = $("#timezone-picker");
-   if (tzPicker.length) {
-     tzPicker.chosen({ max_selected_options:1,
-                       disable_search:true}).
-	      on('change', function(evt, params) { 
-		if (params.selected == 'browser') {
-		  $("#tz").val(tz.name());
-		} else {
-		  $("#tz").val("");
-		}
-		ganglia_form.submit();
-	      });
-     tzPicker.val("{$timezone_option}").trigger('chosen:updated');
-   }
+       var tzPicker = $("#timezone-picker");
+       if (tzPicker.length) {
+         tzPicker.chosen({ max_selected_options:1,
+                           disable_search:true}).
+	          on('change', function(evt, params) {
+		    if (params.selected == 'browser') {
+		      $("#tz").val(tz.name());
+		    } else {
+		      $("#tz").val("");
+		    }
+		    ganglia_form.submit();
+	          });
+         tzPicker.val("{$timezone_option}").trigger('chosen:updated');
+       }
 
-   var dateTimePickerOptions = {
-     showOn: "button",
-     constrainInput: false,
-     buttonImage: "img/calendar.gif",
-     buttonImageOnly: true,
-     showButtonPanel: ("{$timezone_option}" == 'browser')
-   };
+       var dateTimePickerOptions = {
+         showOn: "button",
+         constrainInput: false,
+         buttonImage: "img/calendar.gif",
+         buttonImageOnly: true,
+         showButtonPanel: ("{$timezone_option}" == 'browser')
+       };
 
-   var datepicker_cs = $("#datepicker-cs");
-   if (datepicker_cs[0])
-     datepicker_cs.datetimepicker(dateTimePickerOptions);
+       var datepicker_cs = $("#datepicker-cs");
+       if (datepicker_cs[0])
+         datepicker_cs.datetimepicker(dateTimePickerOptions);
 
-   var datepicker_ce = $("#datepicker-ce");
-   if (datepicker_ce[0])
-     datepicker_ce.datetimepicker(dateTimePickerOptions);
-   
-   initShowEvent();
-   initTimeShift();
- });
+       var datepicker_ce = $("#datepicker-ce");
+       if (datepicker_ce[0])
+         datepicker_ce.datetimepicker(dateTimePickerOptions);
 
+       initShowEvent();
+       initTimeShift();
+     });
+    </script>
+    {$custom_time_head}
+  </head>
+  <body style="background-color: #ffffff;" onunload="g_refresh_timer=null">
+    {if isset($user_header)}
+      {include(file="user_header.tpl")}
+    {/if}
 
-</script>
-{$custom_time_head}
-</head>
-<body style="background-color: #ffffff;" onunload="g_refresh_timer=null">
-{if isset($user_header)}
-{include(file="user_header.tpl")}
-{/if}
+    {if $auth_system_enabled}
+      <div style="float:right">
+        {if $username}
+          Currently logged in as: {$username} | <a href="logout.php">Logout</a>
+        {else}
+          You are not currently logged in. | <a href="login.php">Login</a>
+        {/if}
+      </div>
+      <br style="clear:both"/>
+    {/if}
 
-{if $auth_system_enabled}
-<div style="float:right">
-  {if $username}
-    Currently logged in as: {$username} | <a href="logout.php">Logout</a>
-  {else}
-    You are not currently logged in. | <a href="login.php">Login</a>
-  {/if}
-</div>
-<br style="clear:both"/>
-{/if}
+    <div id="tabs">
+      <div id="tabs-menu", {if $hide_header} style="visibility: hidden; display: none;" {/if}>
+        <ul>
+          <li><a href="#tabs-main">Main</a></li>
+          <li><a href="#tabs-search">Search</a></li>
+          <li><a href="#tabs-main">Views</a></li>
+          <li><a href="aggregate_graphs.php">Aggregate Graphs</a></li>
+          <li><a href="#tabs-main">Compare Hosts</a></li>
+          {if $overlay_events}
+            <li><a href="events.php">Events</a></li>
+          {/if}
+          <li><a href="breakdown_reports.php">Reports</a></li>
+          <li><a href="#tabs-autorotation" onclick="autoRotationChooser();">Automatic Rotation</a></li>
+          <li><a href="#tabs-livedashboard" onclick="liveDashboardChooser();">Live Dashboard</a></li>
+          {if $cubism}
+            <li><a href="cubism_form.php">Cubism</a></li>
+          {/if}
+          <li><a href="#tabs-mobile" onclick="window.location.href='mobile.php';">Mobile</a></li>
+        </ul>
+      </div>
 
-<div id="tabs">
-  <div id="tabs-menu", {if $hide_header} style="visibility: hidden; display: none;" {/if}>
-    <ul>
-      <li><a href="#tabs-main">Main</a></li>
-      <li><a href="#tabs-search">Search</a></li>
-      <li><a href="#tabs-main">Views</a></li>
-      <li><a href="aggregate_graphs.php">Aggregate Graphs</a></li>
-      <li><a href="#tabs-main">Compare Hosts</a></li>
-      {if $overlay_events}
-      <li><a href="events.php">Events</a></li>
-      {/if}
-      <li><a href="breakdown_reports.php">Reports</a></li>
-      <li><a href="#tabs-autorotation" onclick="autoRotationChooser();">Automatic Rotation</a></li>
-      <li><a href="#tabs-livedashboard" onclick="liveDashboardChooser();">Live Dashboard</a></li>
-      {if $cubism}
-      <li><a href="cubism_form.php">Cubism</a></li>
-      {/if}
-      <li><a href="#tabs-mobile" onclick="window.location.href='mobile.php';">Mobile</a></li>
-    </ul>
-  </div>
+      <div id="tabs-main">
+        <form action="{$page}" method="GET" name="ganglia_form">
+          <div style="padding:5px;background-color:#dddddd;display:flex;align-items:center;">
+            <big style="float:left;">
+              <b id="page_title">{$page_title} at {$date}</b>
+            </big>
+            <input style="margin-left:auto;"
+                   class="header_btn"
+                   type="submit"
+                   value="Get Fresh Data"/>
+            <div style="clear:both"></div>
+          </div>
+          <div>
+            <div style="float:left;padding:5px 0 0 0;" id="range_menu" class="nobr">{$range_menu}</div>
+            <div style="float:left;padding:5px 0 0 0;" id="custom_range_menu">{$custom_time}</div>
+            <div style="float:left;padding:5px 0 0 0;" id="timezone">{$timezone_picker}</div>
+            <div style="float:right;padding:5px 0 0 0;">{$additional_buttons}&nbsp;&nbsp;{$alt_view}</div>
+            <div style="clear:both;"></div>
+          </div>
+          {if $context != "cluster" && $context != "cluster-summary"}
+            <input type="hidden" name="m" id="metrics-picker">
+          {/if}
+          {if $context == "meta"}
+            <div style="padding:5px 5px 0 5px;">
+              {$sort_menu}
+            </div>
+          {/if}
+          {if $node_menu != ""}
+            <div id="node_menu" style="padding:5px 5px 0 5px;">
+              {$node_menu}&nbsp;&nbsp;{$additional_filter_options}
+            </div>
+          {/if}
 
-<div id="tabs-main">
-<form action="{$page}" method="GET" name="ganglia_form">
-  <div style="padding:5px;background-color:#dddddd">
-     <big style="float:left;"><b id="page_title">{$page_title} at {$date}</b></big><input style="float:right;" class="header_btn" type="submit" value="Get Fresh Data"/><div style="clear:both"></div>
-  </div>
-  <div style="padding:5px 5px 0 5px;">
-    <div style="float:left;" id="range_menu" class="nobr">{$range_menu}</div>
-    <div style="float:left;" id="custom_range_menu">{$custom_time}</div>
-    <div style="float:left;" id="timezone">{$timezone_picker}</div>
-    <div style="float:right;">{$additional_buttons}&nbsp;&nbsp;{$alt_view}</div>
-    <div style="clear:both;"></div>
-  </div>
-  {if $context != "cluster" && $context != "cluster-summary"}
-  <input type="hidden" name="m" id="metrics-picker">
-  {/if}
-  {if $context == "meta"}
-  <div style="padding:5px 5px 0 5px;">
-    {$sort_menu}
-  </div>
-  {/if}
-  {if $node_menu != ""}
-  <div id="node_menu" style="padding:5px 5px 0 5px;">
-    {$node_menu}&nbsp;&nbsp;{$additional_filter_options}
-  </div>
-  {/if}
-
-<input type="hidden" name="tab" id="selected_tab" value="{$selected_tab}">
-<input type="hidden" id="vn" name="vn" value="{$view_name}">
-<input type="hidden" id="tz" name="tz" value="{$timezone_value}">
-{if $hide_header}
-<input type="hidden" id="hide-hf" name="hide-hf" value="true">
-{else}
-<input type="hidden" id="hide-hf" name="hide-hf" value="false">
-{/if}
-{if $overlay_events}
-<input type="hidden" id="overlay_events" value="true">
-{else}
-<input type="hidden" id="overlay_events" value="false">
-{/if}
-<hr size="1" noshade>
-<!-- End header.tpl -->
+          <input type="hidden" name="tab" id="selected_tab" value="{$selected_tab}">
+          <input type="hidden" id="vn" name="vn" value="{$view_name}">
+          <input type="hidden" id="tz" name="tz" value="{$timezone_value}">
+          {if $hide_header}
+            <input type="hidden" id="hide-hf" name="hide-hf" value="true">
+          {else}
+            <input type="hidden" id="hide-hf" name="hide-hf" value="false">
+          {/if}
+          {if $overlay_events}
+            <input type="hidden" id="overlay_events" value="true">
+          {else}
+            <input type="hidden" id="overlay_events" value="false">
+          {/if}
+          <hr size="1" noshade>
+          <!-- End header.tpl -->

--- a/templates/default/views_view.tpl
+++ b/templates/default/views_view.tpl
@@ -40,7 +40,7 @@
                 } else {
                   if (ul > yAxisUpperLimit)
                     yAxisUpperLimit = ul;
-                } 
+                }
               }
 
 	      var ll = getLimit(data, "min");
@@ -50,12 +50,12 @@
                 } else {
                   if (ll < yAxisLowerLimit)
                     yAxisLowerLimit = ll;
-                } 
+                }
               }
             },
             async: false
           });
-	}    
+	}
     });
 
     var upperLimitChanged = true;
@@ -87,19 +87,19 @@
 	if (src.indexOf("graph.php") == 0) {
 	  var d = new Date();
           if (viewCommonYaxis &&
-              yAxisUpperLimit != null && 
-              yAxisLowerLimit != null && 
+              yAxisUpperLimit != null &&
+              yAxisLowerLimit != null &&
               limitsChanged)
-	    $(this).attr("src", 
+	    $(this).attr("src",
                          jQuery.param.querystring(
-                           src, 
-                           "&x=" + encodeURIComponent(yAxisUpperLimit) + 
+                           src,
+                           "&x=" + encodeURIComponent(yAxisUpperLimit) +
                            "&n=" + encodeURIComponent(yAxisLowerLimit) +
                            "&_=" + d.getTime()));
           else
-	    $(this).attr("src", 
+	    $(this).attr("src",
                          jQuery.param.querystring(src, "&_=" + d.getTime()));
-	}    
+	}
     });
   }
 
@@ -109,8 +109,8 @@
 
   function createView() {
     $("#create-new-view-confirmation-layer").html('<img src="img/spinner.gif">');
-    $.get('views_view.php', 
-          $("#create_view_form").serialize() , 
+    $.get('views_view.php',
+          $("#create_view_form").serialize() ,
           function(data) {
       $("#create-new-view-layer").toggle();
       $("#create-new-view-confirmation-layer").html(data.output);
@@ -132,12 +132,12 @@
     $.get("views_view.php?vn=" + view_name + "&views_menu",
           function(data) {
             $("#views_menu").html(data);
-          }); 
+          });
     {/if}
     var qs = jQuery.deparam.querystring();
-    $.get("view_content.php?vn=" + view_name + 
-  	  "&r=" + qs.r + 
-	  "&cs=" + $("#datepicker-cs").val() + 
+    $.get("view_content.php?vn=" + view_name +
+  	  "&r=" + qs.r +
+	  "&cs=" + $("#datepicker-cs").val() +
 	  "&ce=" + $("#datepicker-ce").val(),
 	  function(data) {
 	    $("#views-content").html(data);
@@ -170,7 +170,7 @@
       .click(function() {
         if ($("#vn").val() != "") {
 	  if (confirm("Are you sure you want to delete the view: " + $("#vn").val() + " ?")) {
-	    $.get('views_view.php?vn=' + 
+	    $.get('views_view.php?vn=' +
                   encodeURIComponent($("#vn").val()) +
                   '&delete_view&views_menu',
                   function(data) {
@@ -183,7 +183,7 @@
                         alert("Please select the view to delete");
                     {else}
                       $("#views_menu").html(data);
-		      $("#view_graphs").html("");  
+		      $("#view_graphs").html("");
 		      $("#vn").val("");
                     {/if}
                   });
@@ -198,7 +198,7 @@
          'multiple' : false,
          'animation' : 0,
 	 'check_callback' : true,
-         'themes' : { 'icons' : false, 'dots' : false, 'stripes' : true }
+         'themes' : { 'icons' : true, 'dots' : true, 'stripes' : false }
       },
       'state' : {
         'filter' : function(n) { delete n.core.selected; return n; },
@@ -206,7 +206,7 @@
       },
       'plugins' : ['state', 'sort', 'unique']
     })
-    .on("select_node.jstree", 
+    .on("select_node.jstree",
           function (event, data) {
 	    if (data.instance.is_leaf(data.node)) {
               selectView(data.node.original.view_name);
@@ -216,7 +216,7 @@
             }
             return false;
           })
-    .on("before.jstree", 
+    .on("before.jstree",
           function (e, data) {
             if (data.func === "select_node" &&
                 !data.inst.is_leaf(data.args[0])) {


### PR DESCRIPTION
Improvements to the dialog content for adding items to views. For example, only display warning/critical fields for metric graphs.
Inspect-graph. Auto-size the multi-select legend box.
Inspect-graph. Remove any residual content from the graph popup that may have been left over from viewing a trend plot.
Cosmetic changes to the used to organize views (if that option is selected).
Change the title of the popup used to add an item to a view. Added missing &s to several query strings.
Added the -t option to the rrdtool xport command. This is a requirement for rrdtool 1.6.0 to replicate the existing data format with a timestamp for each row.
Introduce some spacing between toolbar entries when wrapping occurs. 
Disable refresh of the search view.
Replace individual <script> statements with a common include file.
Graph-all-periods. Reconciled how actions are assciated with graphs in different scenarios. Minor fixes to graph url query strings. Improved conditional templating to make it clearer under what conditions
elements are required.