### PR TITLE
find_avg:  check for existence of rrd file before exec'ing rrdtool

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -309,17 +309,23 @@ function find_avg($clustername, $hostname, $metricname) {
         $sum_dir = "${conf['rrds']}/$clustername/$hostname";
     else
         $sum_dir = "${conf['rrds']}/$clustername/__SummaryInfo__";
-
-    $command = $conf['rrdtool'] . " graph /dev/null $rrd_options ".
-        "--start $start --end $end ".
-        "DEF:avg='$sum_dir/$metricname.rrd':'sum':AVERAGE ".
-        "PRINT:avg:AVERAGE:%.2lf ";
-    exec($command, $out);
-    if ( isset($out[1]) ) 
-      $avg = $out[1];
-    else
-      $avg = 0;
-    #echo "$sum_dir: avg($metricname)=$avg<br>\n";
+    
+    # Confirm that sum_dir exists:
+    if ( is_dir($sum_dir) ) {
+        $rrd_file = "$sum_dir/$metricname.rrd";
+        if ( file_exists($rrd_file) ) {
+            $command = $conf['rrdtool'] . " graph /dev/null $rrd_options ".
+                "--start $start --end $end ".
+                "DEF:avg='$rrd_file':'sum':AVERAGE ".
+                "PRINT:avg:AVERAGE:%.2lf ";
+            exec($command, $out);
+            if ( isset($out[1]) ) 
+              $avg = $out[1];
+            else
+              $avg = 0;
+            #echo "$sum_dir: avg($metricname)=$avg<br>\n";
+        }
+    }
     return $avg;
 }
 


### PR DESCRIPTION
We noted rrdtool crashing when an invalid clustername is passed to ganglia-web (e.g. ?c=not_our_cluster).  While the segfault is due to a bug we isolated in rrdtool when using the caching daemon, it seems appropriate for ganglia-web to check the "c" CGI parameter to ensure it's a defined cluster.  As it stands, this code change simply ensures the find_avg() function doesn't pass any non-existent files to rrdtool.  The check for a valid cluster name should probably be implemented at a higher level, though, which might make the existence of the directory/file a valid precondition to find_avg() and negate this patch.