### PR TITLE
Convert inspect_graph to JS class

### DIFF
--- a/conf_default.php.in
+++ b/conf_default.php.in
@@ -467,7 +467,7 @@ $conf['select2_js_path'] = "https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3
 $conf['select2_css_path'] = "https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css";
 $conf['fullcalendar_js_path'] = "https://cdnjs.cloudflare.com/ajax/libs/fullcalendar/2.9.0/fullcalendar.min.js";
 $conf['fullcalendar_css_path'] = "https://cdnjs.cloudflare.com/ajax/libs/fullcalendar/2.9.0/fullcalendar.min.css";
-
+$conf['jquery_visible_js_path'] = "https://cdnjs.cloudflare.com/ajax/libs/jquery-visible/1.2.0/jquery.visible.min.js";
 $conf['jquery_flot_base_path'] = "https://cdnjs.cloudflare.com/ajax/libs/flot/0.8.3/jquery.flot";
 
 # Enable Cubism integration http://square.github.io/cubism/

--- a/functions.php
+++ b/functions.php
@@ -67,7 +67,7 @@ function uptime($uptimeS) {
 
 #------------------------------------------------------------------------------
 # Try to determine a nodes location in the cluster. Attempts to find the
-# LOCATION attribute first. Requires the host attribute array from 
+# LOCATION attribute first. Requires the host attribute array from
 # $hosts[$cluster][$name], where $name is the hostname.
 # Returns [-1,-1,-1] if we could not determine location.
 #
@@ -215,11 +215,11 @@ function node_image ($metrics) {
 # Finds the min/max over a set of metric graphs. Nodes is
 # an array keyed by host names.
 #
-function find_limits($clustername, 
-		     $nodes, 
-		     $metricname, 
-		     $start, 
-		     $end, 
+function find_limits($clustername,
+		     $nodes,
+		     $metricname,
+		     $start,
+		     $end,
 		     $metrics,
 		     $conf,
 		     $rrd_options) {
@@ -227,7 +227,7 @@ function find_limits($clustername,
     return array(0, 0);
 
   $firsthost = key($metrics);
-   
+
   if (array_key_exists($metricname, $metrics[$firsthost])) {
     if ($metrics[$firsthost][$metricname]['TYPE'] == "string"
         or $metrics[$firsthost][$metricname]['SLOPE'] == "zero")
@@ -239,7 +239,7 @@ function find_limits($clustername,
   $max = 0;
   $min = 0;
   if ($conf['graph_engine'] == "graphite") {
-    $target = $conf['graphite_prefix'] . 
+    $target = $conf['graphite_prefix'] .
       $clustername . ".[a-zA-Z0-9]*." . $metricname . ".sum";
     $raw_highestMax = file_get_contents($conf['graphite_url_base'] . "?target=highestMax(" . $target . ",1)&from=" . $start . "&until=" . $end . "&format=json");
     $highestMax = json_decode($raw_highestMax, TRUE);
@@ -277,14 +277,14 @@ function find_limits($clustername,
 	  } else {
 	    $thismax = NULL;
 	  }
-	  if (!is_numeric($thismax)) 
+	  if (!is_numeric($thismax))
 	    continue;
 	  $thismin = $out[2];
 	  if (!is_numeric($thismin))
 	    continue;
 	}
 
-	if ($max < $thismax) 
+	if ($max < $thismax)
 	  $max = $thismax;
 
 	if ($min > $thismin)
@@ -315,7 +315,7 @@ function find_avg($clustername, $hostname, $metricname) {
         "DEF:avg='$sum_dir/$metricname.rrd':'sum':AVERAGE ".
         "PRINT:avg:AVERAGE:%.2lf ";
     exec($command, $out);
-    if ( isset($out[1]) ) 
+    if ( isset($out[1]) )
       $avg = $out[1];
     else
       $avg = 0;
@@ -337,7 +337,7 @@ function rowstyle() {
 
 #------------------------------------------------------------------------------
 # Return a version of the string which is safe for display on a web page.
-# Potentially dangerous characters are converted to HTML entities.  
+# Potentially dangerous characters are converted to HTML entities.
 # Resulting string is not URL-encoded.
 function clean_string( $string ) {
 
@@ -366,7 +366,7 @@ function is_valid_hex_color( $string ) {
     }
   }
   return $return_value;
-    
+
 }
 
 #------------------------------------------------------------------------------
@@ -384,7 +384,7 @@ function is_proper_view_name( $string ) {
 #------------------------------------------------------------------------------
 # Return a shortened version of a FQDN
 # if "hostname" is numeric only, assume it is an IP instead
-# 
+#
 function strip_domainname( $hostname ) {
     $postition = strpos($hostname, '.');
     $name = substr( $hostname, 0, $postition );
@@ -399,10 +399,10 @@ function strip_domainname( $hostname ) {
 # Read a file containing key value pairs
 function file_to_hash($filename, $sep) {
 
-  
+
   $lines = file($filename, FILE_IGNORE_NEW_LINES);
-  
-  foreach ($lines as $line) 
+
+  foreach ($lines as $line)
   {
     list($k, $v) = explode($sep, rtrim($line));
     $params[$k] = $v;
@@ -416,9 +416,9 @@ function file_to_hash($filename, $sep) {
 # Multiple values permitted for each key
 function file_to_hash_multi($filename, $sep) {
 
- 
+
   $lines = file($filename);
- 
+
   foreach ($lines as $line)
   {
     list($k, $v) = explode($sep, rtrim($line));
@@ -440,7 +440,7 @@ function hash_get_distinct_values($h) {
     {
       $values_done[$v] = "x";
       $values[] = $v;
-    } 
+    }
   }
   return $values;
 }
@@ -511,7 +511,7 @@ function filter_init() {
    foreach($choose_filter as $filter_shortname => $filter_choice)
    {
       if($filter_choice == "")
-         continue; 
+         continue;
 
       $filter_params = $filter_defs[$filter_shortname];
       if($filter_count == 0)
@@ -532,7 +532,7 @@ function filter_init() {
                if($filter_params["data"][$key] == $filter_choice)
                {
                   $remove_key = FALSE;
-               } 
+               }
             }
             if($remove_key)
             {
@@ -555,7 +555,7 @@ function filter_permit($source_name) {
    global $filter_permit_list;
 
    filter_init();
-   
+
    # Handle the case where filtering is not active
    if(!is_array($filter_permit_list))
       return true;
@@ -618,21 +618,21 @@ function getViewItems($view, $range, $cs, $ce) {
   $view_elements = get_view_graph_elements($view);
   $view_items = array();
   if (count($view_elements) != 0) {
-    $graphargs = "";
+    $custom_time_args = "";
     if ($cs)
-      $graphargs .= "&amp;cs=" . rawurlencode($cs);
+      $custom_time_args .= "&cs=" . rawurlencode($cs);
     if ($ce)
-      $graphargs .= "&amp;ce=" . rawurlencode($ce);
-    
+      $custom_time_args .= "&ce=" . rawurlencode($ce);
+
     foreach ($view_elements as $element) {
       $canBeDecomposed = isset($element['aggregate_graph']) ||
 	((strpos($element['graph_args'], 'vn=') !== FALSE) &&
 	 (strpos($element['graph_args'], 'item_id=') !== FALSE));
-      $view_items[] = 
-	array("legend" => isset($element['hostname']) ? 
+      $view_items[] =
+	array("legend" => isset($element['hostname']) ?
 	      $element['hostname'] : "Aggregate graph",
-	      "url_args" => htmlentities($element['graph_args']) . 
-	      "&amp;r=" . $range . $graphargs,
+	      "url_args" => $element['graph_args'] .
+	      "&r=" . $range . $custom_time_args,
 	      "aggregate_graph" => isset($element['aggregate_graph']) ? 1 : 0,
 	      "canBeDecomposed" => $canBeDecomposed ? 1 : 0);
     }
@@ -645,7 +645,7 @@ function getViewItems($view, $range, $cs, $ce) {
 ///////////////////////////////////////////////////////////////////////////////
 function get_available_views() {
   global $conf;
-  
+
   /* -----------------------------------------------------------------------
   Find available views by looking in the GANGLIA_DIR/conf directory
   anything that matches view_*.json. Read them all and build a available_views
@@ -658,26 +658,26 @@ function get_available_views() {
       if (preg_match("/^view_(.*)\.json$/", $file, $out)) {
 	$view_config_file = $conf['views_dir'] . "/" . $file;
 	if (!is_file ($view_config_file)) {
-	  echo("Can't read view config file " . 
+	  echo("Can't read view config file " .
 	       $view_config_file . ". Please check permissions");
 	}
 
 	$view = json_decode(file_get_contents($view_config_file), TRUE);
-	// Check whether view type has been specified ie. regex. 
+	// Check whether view type has been specified ie. regex.
 	// If not it's standard view
-	$view_type = 
+	$view_type =
 	  isset($view['view_type']) ? $view['view_type'] : "standard";
-	$default_size = isset($view['default_size']) ? 
+	$default_size = isset($view['default_size']) ?
 	  $view['default_size'] : $conf['default_view_graph_size'];
-	$view_parent = 
+	$view_parent =
 	  isset($view['parent']) ? $view['parent'] : NULL;
-	$common_y_axis = 
+	$common_y_axis =
 	  isset($view['common_y_axis']) ? $view['common_y_axis'] : 0;
 
-	$available_views[] = array ("file_name" => $view_config_file, 
+	$available_views[] = array ("file_name" => $view_config_file,
 				    "view_name" => $view['view_name'],
-				    "default_size" => $default_size, 
-				    "items" => $view['items'], 
+				    "default_size" => $default_size,
+				    "items" => $view['items'],
 				    "view_type" => $view_type,
 				    "parent" => $view_parent,
 				    "common_y_axis" => $common_y_axis);
@@ -686,27 +686,27 @@ function get_available_views() {
     }
     closedir($handle);
   }
-  
+
   foreach ($available_views as $key => $row) {
     $name[$key] = strtolower($row['view_name']);
   }
-  
+
   @array_multisort($name, SORT_ASC, $available_views);
-  
-  return $available_views; 
+
+  return $available_views;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // Get image graph URLS
-// This function returns an array of graph URLs to be used when rendering the 
-// view. It returns only the base ie. cluster, host, metric information. 
+// This function returns an array of graph URLs to be used when rendering the
+// view. It returns only the base ie. cluster, host, metric information.
 // It is up to the caller to add proper size information, time ranges etc.
 ///////////////////////////////////////////////////////////////////////////////
 function get_view_graph_elements($view) {
   global $conf, $index_array;
 
   retrieve_metrics_cache();
-  
+
   $view_elements = array();
 
   // set the default size from the view or global config
@@ -736,7 +736,7 @@ function get_view_graph_elements($view) {
 
 	  if (isset($item['metric_regex'])) {
 	    foreach ( $item['metric_regex'] as $reg_id => $regex_array ) {
-	      $graph_args_array[] = 
+	      $graph_args_array[] =
 		"mreg[]=" . urlencode($regex_array["regex"]);
               $mreg[] = $regex_array["regex"];
 	    }
@@ -751,23 +751,23 @@ function get_view_graph_elements($view) {
           if ( isset($item['sortit']) ) {
             $graph_args_array[] = "sortit=" . $item['sortit'];
           }
-	  
+
 	  // If graph type is not specified default to line graph
-	  if (isset($item['graph_type']) && 
+	  if (isset($item['graph_type']) &&
 	      in_array($item['graph_type'], array('line', 'stack')))
 	    $graph_args_array[] = "gtype=" . $item['graph_type'];
 	  else
 	    $graph_args_array[] = "gtype=line";
-	  
+
 	  if (isset($item['upper_limit']))
 	    $graph_args_array[] = "x=" . $item['upper_limit'];
-	  
+
 	  if (isset($item['lower_limit']))
 	    $graph_args_array[] = "n=" . $item['lower_limit'];
-	  
+
 	  if (isset($item['vertical_label']))
 	    $graph_args_array[] = "vl=" . urlencode($item['vertical_label']);
-	  
+
 	  if (isset($item['title']))
 	    $graph_args_array[] = "title=" . urlencode($item['title']);
 
@@ -781,29 +781,29 @@ function get_view_graph_elements($view) {
 	    $graph_args_array[] = "c=" . urlencode($item['cluster']);
 
 	  if (isset($item['exclude_host_from_legend_label']))
-	    $graph_args_array[] = 
+	    $graph_args_array[] =
 	      "lgnd_xh=" . $item['exclude_host_from_legend_label'];
-	  
+
 	  $graph_args_array[] = "aggregate=1";
-	  $view_elements[] = 
-	    array("graph_args" => join("&", $graph_args_array), 
+	  $view_elements[] =
+	    array("graph_args" => join("&", $graph_args_array),
 		  "aggregate_graph" => 1,
-		  "name" => isset($item['title']) && $item['title'] != "" ? 
+		  "name" => isset($item['title']) && $item['title'] != "" ?
 		  $item['title'] : $mreg[0] . " Aggregate graph");
-	  
+
 	  unset($graph_args_array);
-          
-	  // Check whether it's a composite graph/report. 
+
+	  // Check whether it's a composite graph/report.
 	  // It needs to have an item id
 	} else if ($item['item_id']) {
 	  $graph_args_array[] = "vn=" . $view['view_name'];
           $graph_args_array[] = "item_id=" . $item['item_id'];
 
-	  $view_elements[] = 
+	  $view_elements[] =
 	    array("graph_args" => join("&", $graph_args_array));
           unset($graph_args_array);
-          
-	  // It's standard metric graph          
+
+	  // It's standard metric graph
         } else {
 	  // Is it a metric or a graph(report)
 	  if (isset($item['metric'])) {
@@ -835,16 +835,16 @@ function get_view_graph_elements($view) {
 
 	  if (isset($item['upper_limit']))
 	    $graph_args_array[] = "x=" . $item['upper_limit'];
-	  
+
 	  if (isset($item['lower_limit']))
 	    $graph_args_array[] = "n=" . $item['lower_limit'];
-	  
+
 	  if (isset($item['vertical_label']))
 	    $graph_args_array[] = "vl=" . urlencode($item['vertical_label']);
-	  
+
 	  if (isset($item['title']))
 	    $graph_args_array[] = "title=" . urlencode($item['title']);
-	  
+
           if (isset($item['warning'])) {
             $view_e['warning'] = $item['warning'];
             $graph_args_array[] = "warn=" . $item['warning'];
@@ -862,9 +862,9 @@ function get_view_graph_elements($view) {
           $view_e['hostname'] = $hostname;
           $view_e['cluster'] = $cluster;
           $view_e['name'] = $name;
-	  
+
 	  $view_elements[] = $view_e;
-	  
+
           unset($view_e);
 	  unset($graph_args_array);
 	}
@@ -885,7 +885,7 @@ function get_view_graph_elements($view) {
 	$metric_suffix = "g=" . $item['graph'];
 	$name = $item['graph'];
       }
-      
+
       // Find hosts matching a criteria
       $query = $item['hostname'];
       foreach ( $index_array['hosts'] as $key => $host_name ) {
@@ -895,12 +895,12 @@ function get_view_graph_elements($view) {
 	    $graph_args_array[] = "h=" . urlencode($host_name);
 	    $graph_args_array[] = "c=" . urlencode($cluster);
 
-	    $view_elements[] = 
-	      array("graph_args" => $metric_suffix . "&" . join("&", $graph_args_array), 
+	    $view_elements[] =
+	      array("graph_args" => $metric_suffix . "&" . join("&", $graph_args_array),
 		    "hostname" => $host_name,
 		    "cluster" => $cluster,
 		    "name" => $name);
-	    
+
 	    unset($graph_args_array);
 	  }
 	}
@@ -952,7 +952,7 @@ function legendEntry($vname, $legend_items) {
     $legend .= "GPRINT:'{$vname}_max':'Max\:%5.1lf%s";
     $terminate = TRUE;
   }
-  
+
   if ($terminate)
     $legend .= "\\l' ";
 
@@ -971,51 +971,51 @@ function legendEntry($vname, $legend_items) {
  *   checkAccess( 'cluster1', GangliaAcl::VIEW, $conf ); // user has view privilege on cluster1?
  */
 function checkAccess($resource, $privilege, $conf) {
-  
+
   if(!is_array($conf)) {
     trigger_error('checkAccess: $conf is not an array.', E_USER_ERROR);
   }
   if(!isset($conf['auth_system'])) {
     trigger_error("checkAccess: \$conf['auth_system'] is not defined.", E_USER_ERROR);
   }
-  
+
   switch( $conf['auth_system'] ) {
     case 'readonly':
       $out = ($privilege == GangliaAcl::VIEW);
       break;
-      
+
     case 'enabled':
       // TODO: 'edit' needs to check for writeability of data directory.  error log if edit is allowed but we're unable to due to fs problems.
-      
+
       $acl = GangliaAcl::getInstance();
       $auth = GangliaAuth::getInstance();
-      
+
       if(!$auth->isAuthenticated()) {
         $user = GangliaAcl::GUEST;
       } else {
         $user = $auth->getUser();
       }
-      
+
       if(!$acl->has($resource)) {
         $resource = GangliaAcl::ALL_CLUSTERS;
       }
-      
+
       $out = false;
       if($acl->hasRole($user)) {
         $out = (bool) $acl->isAllowed($user, $resource, $privilege);
       }
       // error_log("checkAccess() user=$user, resource=$resource, priv=$privilege == $out");
       break;
-    
+
     case 'disabled':
       $out = true;
       break;
-    
+
     default:
       trigger_error( "Invalid value '".$conf['auth_system']."' for \$conf['auth_system'].", E_USER_ERROR );
       return false;
   }
-  
+
   return $out;
 }
 
@@ -1027,79 +1027,79 @@ function viewId($view_name) {
 ///////////////////////////////////////////////////////////////////////////////
 // Taken from
 // http://au2.php.net/manual/en/function.json-encode.php#80339
-// Pretty print JSON 
+// Pretty print JSON
 ///////////////////////////////////////////////////////////////////////////////
-function json_prettyprint($json) { 
- 
-    $tab = "  "; 
-    $new_json = ""; 
-    $indent_level = 0; 
-    $in_string = false; 
+function json_prettyprint($json) {
 
-    $len = strlen($json); 
+    $tab = "  ";
+    $new_json = "";
+    $indent_level = 0;
+    $in_string = false;
 
-    for($c = 0; $c < $len; $c++) 
-    { 
-        $char = $json[$c]; 
-        switch($char) 
-        { 
-            case '{': 
-            case '[': 
-                if(!$in_string) 
-                { 
-                    $new_json .= $char . "\n" . str_repeat($tab, $indent_level+1); 
-                    $indent_level++; 
-                } 
-                else 
-                { 
-                    $new_json .= $char; 
-                } 
-                break; 
-            case '}': 
-            case ']': 
-                if(!$in_string) 
-                { 
-                    $indent_level--; 
-                    $new_json .= "\n" . str_repeat($tab, $indent_level) . $char; 
-                } 
-                else 
-                { 
-                    $new_json .= $char; 
-                } 
-                break; 
-            case ',': 
-                if(!$in_string) 
-                { 
-                    $new_json .= ",\n" . str_repeat($tab, $indent_level); 
-                } 
-                else 
-                { 
-                    $new_json .= $char; 
-                } 
-                break; 
-            case ':': 
-                if(!$in_string) 
-                { 
-                    $new_json .= ": "; 
-                } 
-                else 
-                { 
-                    $new_json .= $char; 
-                } 
-                break; 
-            case '"': 
-                if($c > 0 && $json[$c-1] != '\\') 
-                { 
-                    $in_string = !$in_string; 
-                } 
-            default: 
-                $new_json .= $char; 
-                break;                    
-        } 
-    } 
+    $len = strlen($json);
 
-    return $new_json; 
-} 
+    for($c = 0; $c < $len; $c++)
+    {
+        $char = $json[$c];
+        switch($char)
+        {
+            case '{':
+            case '[':
+                if(!$in_string)
+                {
+                    $new_json .= $char . "\n" . str_repeat($tab, $indent_level+1);
+                    $indent_level++;
+                }
+                else
+                {
+                    $new_json .= $char;
+                }
+                break;
+            case '}':
+            case ']':
+                if(!$in_string)
+                {
+                    $indent_level--;
+                    $new_json .= "\n" . str_repeat($tab, $indent_level) . $char;
+                }
+                else
+                {
+                    $new_json .= $char;
+                }
+                break;
+            case ',':
+                if(!$in_string)
+                {
+                    $new_json .= ",\n" . str_repeat($tab, $indent_level);
+                }
+                else
+                {
+                    $new_json .= $char;
+                }
+                break;
+            case ':':
+                if(!$in_string)
+                {
+                    $new_json .= ": ";
+                }
+                else
+                {
+                    $new_json .= $char;
+                }
+                break;
+            case '"':
+                if($c > 0 && $json[$c-1] != '\\')
+                {
+                    $in_string = !$in_string;
+                }
+            default:
+                $new_json .= $char;
+                break;
+        }
+    }
+
+    return $new_json;
+}
 
 function ganglia_cache_metrics() {
     global $conf, $index_array, $hosts, $grid, $clusters, $debug, $metrics;
@@ -1111,8 +1111,8 @@ function ganglia_cache_metrics() {
 //////////////////////////////////////////////////////////////////////////////
 //
 //////////////////////////////////////////////////////////////////////////////
-function build_aggregate_graph_config ($graph_type, 
-                                       $line_width, 
+function build_aggregate_graph_config ($graph_type,
+                                       $line_width,
                                        $hreg,
                                        $mreg,
                                        $glegend,
@@ -1120,9 +1120,9 @@ function build_aggregate_graph_config ($graph_type,
                                        $sortit = true) {
 
   global $conf, $index_array, $hosts, $grid, $clusters, $debug, $metrics;
-  
+
   retrieve_metrics_cache();
-  
+
   $color_count = count($conf['graph_colors']);
 
   $graph_config["report_name"]=isset($mreg)  ?  sanitize(implode($mreg))   : NULL;
@@ -1132,7 +1132,7 @@ function build_aggregate_graph_config ($graph_type,
   $counter = 0;
 
   ///////////////////////////////////////////////////////////////////////////
-  // Find matching hosts    
+  // Find matching hosts
   foreach ( $hreg as $key => $query ) {
     foreach ( $index_array['hosts'] as $key => $host_name ) {
       if ( preg_match("/$query/i", $host_name ) ) {
@@ -1142,7 +1142,7 @@ function build_aggregate_graph_config ($graph_type,
         }
       }
     }
-  } 
+  }
 
   sort($host_matches);
 
@@ -1234,13 +1234,13 @@ function retrieve_metrics_cache ( $index = "all" ) {
    return;
 } // end of function get_metrics_cache () {
 
-function getHostOverViewData($hostname, 
-                             $metrics, 
+function getHostOverViewData($hostname,
+                             $metrics,
                              $cluster,
-                             $hosts_up, 
-                             $hosts_down, 
-                             $always_timestamp, 
-                             $always_constant, 
+                             $hosts_up,
+                             $hosts_down,
+                             $always_timestamp,
+                             $always_constant,
                              $data) {
   $data->assign("extra", template("host_extra.tpl"));
 
@@ -1248,9 +1248,9 @@ function getHostOverViewData($hostname,
   $data->assign("node_image", node_image($metrics));
 
   if ($hosts_up)
-    $data->assign("node_msg", "This host is up and running."); 
+    $data->assign("node_msg", "This host is up and running.");
   else
-    $data->assign("node_msg", "This host is down."); 
+    $data->assign("node_msg", "This host is down.");
 
   # No reason to go on if this node is down.
   if ($hosts_down)
@@ -1307,7 +1307,7 @@ function getHostOverViewData($hostname,
       } else {
         $s_metrics_data[$name]["name"] = $name;
       }
-      if ($v['TYPE']=="timestamp" or 
+      if ($v['TYPE']=="timestamp" or
           (isset($always_timestamp[$name]) and $always_timestamp[$name])) {
         $s_metrics_data[$name]["value"] = date("r", $v['VAL']);
       } else {
@@ -1341,7 +1341,7 @@ function buildMetricMaps($metrics,
   $metricMap = NULL;
   $metricGroupMap = NULL;
   foreach ($metrics as $name => $metric) {
-    if ($metric['TYPE'] == "string" or 
+    if ($metric['TYPE'] == "string" or
 	$metric['TYPE'] == "timestamp" or
 	(isset($always_timestamp[$name]) and $always_timestamp[$name])) {
       continue;
@@ -1349,23 +1349,23 @@ function buildMetricMaps($metrics,
 	      (isset($always_constant[$name]) and $always_constant[$name])) {
       continue;
     } else {
-      $graphArgs = $baseGraphArgs . "&amp;v=$metric[VAL]&amp;m=$name";
+      $graphArgs = $baseGraphArgs . "&v=$metric[VAL]&m=$name";
       # Adding units to graph 2003 by Jason Smith <smithj4@bnl.gov>.
       if ($metric['UNITS']) {
 	$encodeUnits = rawurlencode($metric['UNITS']);
-	$graphArgs .= "&amp;vl=$encodeUnits";
+	$graphArgs .= "&vl=$encodeUnits";
       }
       if (isset($metric['TITLE'])) {
 	$title = $metric['TITLE'];
 	$encodeTitle = rawurlencode($title);
-	$graphArgs .= "&amp;ti=$encodeTitle";
+	$graphArgs .= "&ti=$encodeTitle";
       }
       // dump_var($graphArgs, "graphArgs");
 
       $metricMap[$name]['graph'] = $graphArgs;
-      $metricMap[$name]['description'] = 
+      $metricMap[$name]['description'] =
 	isset($metric['DESC']) ? $metric['DESC'] : '';
-      $metricMap[$name]['title'] = 
+      $metricMap[$name]['title'] =
 	isset($metric['TITLE']) ? $metric['TITLE'] : '';
 
       # Setup an array of groups that can be used for sorting in group view
@@ -1377,7 +1377,7 @@ function buildMetricMaps($metrics,
 
       foreach ($groups as $group) {
 	if (isset($metricGroupMap[$group])) {
-	  $metricGroupMap[$group] = 
+	  $metricGroupMap[$group] =
 	    array_merge($metricGroupMap[$group], (array)$name);
 	} else {
 	  $metricGroupMap[$group] = array($name);

--- a/graph.d/metric.php
+++ b/graph.d/metric.php
@@ -117,7 +117,7 @@ function graph_metric ( &$rrdtool_graph ) {
 
     //# the actual graph...
     $series  = "DEF:'sum'='$rrd_dir/$metricname.rrd:sum':AVERAGE ";
-    $series .= "AREA:'sum'#${conf['default_metric_color']}:'$subtitle_one   '";
+    $series .= "AREA:'sum'#${conf['default_metric_color']}:'$metricname   '";
 
     if ($conf['graphreport_stats'] == false) {
         $series .= ":STACK: COMMENT:'$subtitle_two\\l'";
@@ -150,8 +150,8 @@ function graph_metric ( &$rrdtool_graph ) {
     // If metric is not present we are likely not collecting it on this
     // host therefore we should not attempt to build anything and will likely end up with a broken
     // image. To avoid that we'll make an empty image
-    if ( !file_exists("$rrd_dir/$metricname.rrd") ) 
-      $rrdtool_graph[ 'series' ] = 'HRULE:1#FFCC33:"No matching metrics detected"';   
+    if ( !file_exists("$rrd_dir/$metricname.rrd") )
+      $rrdtool_graph[ 'series' ] = 'HRULE:1#FFCC33:"No matching metrics detected"';
     else
       $rrdtool_graph[ 'series' ] = $series;
 

--- a/js/flot_graph.js
+++ b/js/flot_graph.js
@@ -1,0 +1,545 @@
+var VALUE_SEPARATOR = " :: ";
+
+function formattedSiVal(val, places) {
+  if (val >= 1000000000) {
+    return (val / 1000000000).toFixed(places) + " G";
+  }
+  if (val >= 1000000) {
+    return (val / 1000000).toFixed(places) + " M";
+  }
+  if (val >= 1000) {
+    return (val / 1000).toFixed(places) + " k";
+  }
+
+  return (val/1).toFixed(places);
+}
+
+function suffixFormatter(val, axis) {
+  var tickd = axis.tickDecimals;
+  if (tickd <= 0) {
+    tickd = 1;
+  }
+
+  return formattedSiVal(val, tickd);
+}
+
+function zeroOutMissing(dataset, index) {
+  if (dataset.data == null || index < 0)
+    return;
+
+  for (var i = 0; i <= index; i++) {
+    if (dataset.data[i][1] == "NaN")
+      dataset.data[i][1] = 0;
+  }
+}
+
+function lastUpdateIndex(datasets) {
+  var index = 0;
+  $.each(datasets, function(key, dataset) {
+    if (dataset.data == null)
+      return;
+
+    for (var i = dataset.data.length - 1;
+	 i >= 0 && i > index;
+	 i--) {
+      if (dataset.data[i][1] != "NaN") {
+	index = i;
+	break;
+      }
+    }
+  });
+  return index;
+}
+
+var g_flot_graph_counter = 0;
+
+function FlotGraph(graphArgs, refreshInterval, timezone) {
+  this.dataurl = "graph.php?flot=1&" + graphArgs;
+  this.refreshInterval = refreshInterval;
+  this.uuid = "flot_graph_" + g_flot_graph_counter++;
+  this.refresh_timer = null;
+  this.plot = null;
+  this.zooming = false;
+  this.$placeHolder = null;
+  this.$graphControls = null;
+  this.$spacer = null;
+  this.$selectSeries = null;
+  this.$tooltip = null;
+  this.lastUpdate = 0;
+  this.tz = timezone;
+  this.html = "";
+  this.plotOpt = null;
+  this.datasets = null;
+  this.graph_title = null;
+  this.legendColorBox = {};
+  this.stackOpt = null;
+}
+
+FlotGraph.prototype.placeHolderId = function() {
+  return this.uuid + '_placeholder';
+}
+
+FlotGraph.prototype.spacerId = function() {
+  return this.uuid + '_spacer';
+}
+
+FlotGraph.prototype.graphControlsId = function() {
+  return this.uuid + '_graphcontrols';
+}
+
+FlotGraph.prototype.selectSeriesId = function() {
+  return this.uuid + '_select_series';
+}
+
+FlotGraph.prototype.gOptId = function() {
+  return this.uuid + '_gopt';
+}
+
+FlotGraph.prototype.lineId = function() {
+  return this.uuid + '_line';
+}
+
+FlotGraph.prototype.stackId = function() {
+  return this.uuid + '_stack';
+}
+
+FlotGraph.prototype.clearStackOptId = function() {
+  return this.uuid + '_clear_stack_opt';
+}
+
+FlotGraph.prototype.resetZoomId = function() {
+  return this.uuid + '_resetzoom';
+}
+
+FlotGraph.prototype.tooltipId = function() {
+  return this.uuid + '_tooltip';
+}
+
+FlotGraph.prototype.getBaseHtml = function() {
+  this.html = '<div id="' + this.placeHolderId() + '" style="overflow:hidden"></div><div id="' + this.spacerId() + '" style="height:5px;"></div><div id="' + this.graphControlsId() + '"><select id="' + this.selectSeriesId() + '" name="' + this.selectSeriesId() + '" multiple="multiple"></select><span id="' + this.gOptId() + '" style="margin-left:10px;"><input type="radio" id="' + this.lineId() + '" name="' + this.gOptId() + '"/><label style="font-size:0.825em;" for="' + this.lineId() + '">Line</label><input type="radio" id="' + this.stackId() + '" name="' + this.gOptId() + '"/><label style="font-size:0.825em" for="' + this.stackId() + '">Stack</label><input id="' + this.clearStackOptId() + '" type="button" style="font-size:0.825em;" value="Clear"/></span><input id="' + this.resetZoomId() + '" type="button" style="font-size:0.825em;margin-left:10px;" value="Reset zoom"/></div>';
+  return this.html;
+}
+
+FlotGraph.prototype.onEventsReceived = function(overlay_events) {
+  var events = [];
+  $.each(overlay_events, function(key, val) {
+    var event = {};
+    event['min'] = val['start_time'] * 1000;
+    event['max'] = val['end_time'] * 1000;
+    event['eventType'] = 'info';
+    event['title'] = val['summary'];
+    event['description'] = val['description'];
+    events[events.length] = event;
+  });
+
+  var event_types = {};
+  event_types["info"] = {eventType: "info",
+                         level: 1,
+                         icon: {image: "img/red-pointer.png",
+                                width: 10,
+                                height: 10}};
+
+  this.plotOpt.events = {
+    levels: 1,
+    data: events,
+    types: event_types,
+    xaxis: 1
+  };
+
+  this.plotAccordingToChoices();
+
+  if ((!this.zooming) && (this.dataurl.indexOf("&r=custom") == -1)) {
+    var thisGraph = this;
+    this.refresh_timer = setTimeout(
+      function() {
+        thisGraph.refresh();
+      },
+      this.refreshInterval * 1000);
+  }
+}
+
+FlotGraph.prototype.onDataReceived = function(series) {
+  this.datasets = series;
+
+  var series_labels =
+    this.$selectSeries.children("option").map(function() {
+      var text = $(this).text();
+      var label = text;
+      if (text.indexOf(VALUE_SEPARATOR) != -1)
+	label = text.split(VALUE_SEPARATOR)[0];
+      return label;
+    });
+  var series_options = this.$selectSeries.children("option").map(function() {
+    return $(this);
+  });
+
+  var start_time = Number.MAX_VALUE;
+  var end_time = 0;
+
+  // Determine point index corresponding to last update
+  // Typically the dataset will have trailing NaNs that
+  // should be ignored
+  this.lastUpdate = lastUpdateIndex(this.datasets);
+
+  var thisGraph = this;
+  var i = 0;
+  $.each(this.datasets, function(key, dataset) {
+    if (dataset.data == null)
+      return;
+
+    start_time = Math.min(dataset.data[0][0], start_time);
+    end_time = Math.max(dataset.data[dataset.data.length - 1][0],
+			end_time);
+
+    if (thisGraph.stackOpt == "stack")
+      dataset.stack = 1;
+
+    if (thisGraph.stackOpt == "line")
+      delete dataset.stack;
+
+    dataset.lines = { show: true };
+    dataset.lines.fill = ("stack" in dataset);
+
+    if ((thisGraph.graph_title == null) && ("graph_title" in dataset))
+      thisGraph.graph_title = dataset.graph_title;
+
+    if (typeof dataset.color == 'undefined')
+      dataset.color = i;
+
+    i++;
+
+    var current_value = dataset.data[thisGraph.lastUpdate][1];
+    if (current_value != "NaN")
+      current_value = formattedSiVal(current_value, 2);
+    else
+      current_value = "";
+    var seriesIndex = $.inArray(dataset.label, series_labels);
+    var option = null;
+    if (seriesIndex == -1) {
+      option = $('<option/>',
+	             {value: key,
+	              text: dataset.label +
+	              VALUE_SEPARATOR +
+	              current_value});
+      option.prop('selected', true);
+      thisGraph.legendColorBox[dataset.label] = '<div style="border:1px solid #ccc;padding:1px;display:inline-block;"><div style="width:4px;height:0;border:5px solid ' + dataset.color + ';overflow:hidden"></div></div>';
+      option.appendTo(thisGraph.$selectSeries);
+    } else {
+      option = series_options[seriesIndex];
+      var label = series_labels[seriesIndex] +
+	    VALUE_SEPARATOR +
+	    current_value;
+      option.text(label);
+    }
+  });
+
+  this.$selectSeries.multiselect('refresh');
+
+  // Add color keys into the legend
+  this.$selectSeries.multiselect("widget").find("label").each(function() {
+    var datasetName = $(this).text().split(VALUE_SEPARATOR)[0];
+    $(this).prepend($(thisGraph.legendColorBox[datasetName]));
+  });
+
+  $.ajax({
+    url: "get_overlay_events.php?start=" + (start_time/1000) + "&end=" + (end_time/1000),
+    method: 'GET',
+    dataType: 'json',
+    context: this,
+    success: this.onEventsReceived
+  });
+}
+
+FlotGraph.prototype.showTooltip = function(x, y, contents) {
+  this.$tooltip = $('<div id="' + this.tooltipId() + '">' + contents + '</div>').css( {
+    position: 'absolute',
+    display: 'none',
+    'z-index': 2000,
+    top: y - 20,
+    left: x + 10,
+    border: '1px solid #fdd',
+    padding: '2px',
+    'background-color': '#fee',
+    opacity: 1.0
+  }).appendTo("body").fadeIn(200);
+}
+
+function selectRangeHandler(event, ranges) {
+  var thisGraph = event.data.thisGraph;
+
+  // If this selection is being generated by the event plugin then
+  // dont zoom into the specified region
+  if (thisGraph.plot.viewingEvent())
+    return;
+
+  var plotRanges = ranges;
+
+  if (plotRanges.xaxis.to - plotRanges.xaxis.from < 0.00001)
+    plotRanges.xaxis.to = plotRanges.xaxis.from + 0.00001;
+  if (plotRanges.yaxis.to - plotRanges.yaxis.from < 0.00001)
+    plotRanges.yaxis.to = plotRanges.yaxis.from + 0.00001;
+
+  thisGraph.plotOpt.xaxis.min = plotRanges.xaxis.from;
+  thisGraph.plotOpt.xaxis.max = plotRanges.xaxis.to;
+  thisGraph.plotOpt.yaxis.min = plotRanges.yaxis.from;
+  thisGraph.plotOpt.yaxis.max = plotRanges.yaxis.to;
+
+  thisGraph.zooming = true;
+  thisGraph.plotAccordingToChoices();
+}
+
+function hoverHandler(event, pos, item) {
+  var thisGraph = event.data.thisGraph;
+
+  if (item) {
+    if (thisGraph.$tooltip != null) {
+      thisGraph.$tooltip.remove();
+      thisGraph.$tooltip = null;
+    }
+    var y = formattedSiVal(item.datapoint[1], 2);
+    var time = (thisGraph.tz === "browser") ?
+	  moment(item.datapoint[0]) :
+          moment(item.datapoint[0]).tz(thisGraph.tz);
+    thisGraph.showTooltip(item.pageX,
+		          item.pageY,
+		          item.series.label + " at " +
+		          time.format("MM/DD/YYYY HH:mm:ss") +
+		          " = " + y);
+  } else {
+    if (thisGraph.$tooltip != null) {
+      thisGraph.$tooltip.remove();
+      thisGraph.$tooltip = null;
+    }
+  }
+}
+
+FlotGraph.prototype.refresh = function() {
+  $.ajax({
+    url: this.dataurl + '&maxrows=' + this.$placeHolder.width(),
+    method: 'GET',
+    dataType: 'json',
+    context: this,
+    success: this.onDataReceived});
+};
+
+FlotGraph.prototype.setTimezone = function(tz) {
+  this.tz = getTimezone();
+  this.plot.getOptions().xaxis.timezone = this.tz;
+};
+
+FlotGraph.prototype.updatePlotOptions = function() {
+  this.plot.getOptions().events.data = this.plotOpt.events.data;
+  if (this.zooming) {
+    this.plot.getOptions().xaxes[0].min = this.plotOpt.xaxis.min;
+    this.plot.getOptions().xaxes[0].max = this.plotOpt.xaxis.max;
+    this.plot.getOptions().yaxes[0].min = this.plotOpt.yaxis.min;
+    this.plot.getOptions().yaxes[0].max = this.plotOpt.yaxis.max;
+  } else {
+    delete this.plot.getOptions().xaxes[0].min;
+    delete this.plot.getOptions().xaxes[0].max;
+    delete this.plot.getOptions().yaxes[0].min;
+    delete this.plot.getOptions().yaxes[0].max;
+  }
+};
+
+FlotGraph.prototype.plotAccordingToChoices = function() {
+  var selected_series = this.$selectSeries.multiselect("getChecked").map(
+    function() {
+      return this.value;
+    }).get();
+
+  var data = [];
+  for (var i = 0; i < selected_series.length; i++) {
+    var dataset = this.datasets[selected_series[i]];
+    data.push(dataset);
+    // The Flot stack plugin does not handle missing data correctly
+    if ("stack" in dataset)
+      zeroOutMissing(dataset, this.lastUpdate);
+  }
+
+  if (this.plot == null) {
+    this.plot = $.plot(this.$placeHolder, data, this.plotOpt);
+  } else {
+    this.plot.clearEvents();
+    this.plot.clearSelection();
+    this.updatePlotOptions(); // must precede call to setData()
+    this.plot.setData(data);
+    this.plot.setupGrid();
+    this.plot.draw();
+  }
+};
+
+function setStackOpt(event) {
+  var thisGraph = event.data.thisGraph;
+  thisGraph.setStackOpt(event.data.stackOpt);
+};
+
+FlotGraph.prototype.resize = function() {
+  var $parent = this.$placeHolder.parent();
+  this.$placeHolder.height($parent.height() -
+		           this.$graphControls.height() -
+		           this.$spacer.height());
+  this.$placeHolder.width($parent.width());
+};
+
+FlotGraph.prototype.initialize = function() {
+  this.$spacer = $(document).find("#" + this.spacerId());
+  this.$placeHolder = $(document).find("#" + this.placeHolderId());
+  this.$placeHolder.bind("plothover", {thisGraph: this}, hoverHandler);
+  this.$placeHolder.bind("plotselected", {thisGraph: this}, selectRangeHandler);
+  this.$graphControls = $(document).find("#" + this.graphControlsId());
+
+  var thisGraph = this;
+
+  this.$selectSeries = this.$graphControls.find("#" + this.selectSeriesId());
+  this.$selectSeries.multiselect({
+    height: "auto",
+    position : {
+      my: "right bottom",
+      at: "left top"
+    },
+    checkAll: function(event, ui) {
+      thisGraph.plotAccordingToChoices();
+    },
+    uncheckAll: function(event, ui) {
+      thisGraph.plotAccordingToChoices();
+    },
+    click: function(event, ui) {
+      thisGraph.plotAccordingToChoices();
+    }
+  }).multiselectfilter();
+  $(".ui-multiselect-menu").draggable();
+
+  this.$graphControls.find("#" + this.gOptId()).controlgroup();
+
+  var $selectLine = this.$graphControls.find("#" + this.lineId());
+  $selectLine.checkboxradio({icon: false}).click(
+    {thisGraph: this, stackOpt: "line"},
+    setStackOpt);
+
+  var $selectStack = this.$graphControls.find("#" + this.stackId());
+  $selectStack.checkboxradio({icon: false}).click(
+    {thisGraph: this, stackOpt: "stack"},
+    setStackOpt);
+
+  var $clearStackOpt = this.$graphControls.find("#" + this.clearStackOptId());
+  $clearStackOpt.button();
+  $clearStackOpt.click(
+    {thisGraph: this, stackOpt: null},
+    function (event) {
+      $selectStack.prop("checked", false).checkboxradio("refresh");
+      $selectLine.prop("checked", false).checkboxradio("refresh");
+      setStackOpt(event);
+    });
+
+  this.resetZoomElem = this.$graphControls.find("#" + this.resetZoomId());
+  this.resetZoomElem.button();
+  this.resetZoomElem.click(
+    {thisGraph: this},
+    function (event) {
+      var thisGraph = event.data.thisGraph;
+      delete thisGraph.plotOpt.xaxis.min;
+      delete thisGraph.plotOpt.xaxis.max;
+      delete thisGraph.plotOpt.yaxis.min;
+      delete thisGraph.plotOpt.yaxis.max;
+      thisGraph.zooming = false;
+      thisGraph.plotAccordingToChoices();
+    });
+
+  this.resize();
+
+  this.plotOpt =  {
+    points: { show: false },
+    crosshair: { mode: "x" },
+    xaxis: { mode: "time", timezone: this.tz },
+    yaxis: {tickFormatter: suffixFormatter},
+    selection: { mode: "xy" },
+    legend: {show : false},
+    grid: { hoverable: true, autoHighlight: true }
+  };
+};
+
+FlotGraph.prototype.setStackOpt = function(stackOpt) {
+  this.stackOpt = stackOpt;
+
+  if (this.refresh_timer) {
+    clearTimeout(this.refresh_timer);
+    this.refresh_timer = null;
+  }
+  this.refresh();
+};
+
+FlotGraph.prototype.start = function() {
+  $.ajax({
+    url: this.dataurl + '&maxrows=' + this.$placeHolder.width(),
+    method: 'GET',
+    dataType: 'json',
+    context: this,
+    success: this.onDataReceived
+  });
+};
+
+FlotGraph.prototype.shutdown = function() {
+  if (this.refresh_timer) {
+    clearTimeout(this.refresh_timer);
+    this.refresh_timer = null;
+  }
+  this.plot.shutdown();
+  this.$placeHolder.unbind("plothover");
+  this.$placeHolder.unbind("plotselected");
+};
+
+function InspectGraph(graphArgs,
+                      refreshInterval,
+                      timezone,
+                      dialog) {
+  FlotGraph.call(this, graphArgs, refreshInterval, timezone);
+  this.$dialog = $(dialog);
+  this.first_time = true;
+}
+
+InspectGraph.prototype = Object.create(FlotGraph.prototype);
+
+InspectGraph.prototype.resize = function() {
+  this.$placeHolder.height(this.$dialog.height() -
+		           this.$graphControls.height() -
+		           this.$spacer.height());
+};
+
+InspectGraph.prototype.initialize = function() {
+  FlotGraph.prototype.initialize.call(this);
+  this.$dialog.bind("dialogresizestop.inspect",
+                    {thisGraph: this},
+		    function(event) {
+                      var thisGraph = event.data.thisGraph;
+		      thisGraph.resize();
+		      thisGraph.plot.resize();
+		      thisGraph.plotAccordingToChoices();
+		    });
+  this.$dialog.bind("dialogclose.inspect",
+                    {thisGraph: this},
+		    function(event) {
+                      var thisGraph = event.data.thisGraph;
+		      $(this).unbind(".inspect");
+                      thisGraph.shutdown();
+		    });
+};
+
+InspectGraph.prototype.onDataReceived = function(series) {
+  if (this.first_time) {
+    $("#popup-dialog-navigation").html("");
+
+    if ((this.$dialog.dialog("option", "height") == "auto") ||
+	(this.$dialog.dialog("option", "width") == "auto")) {
+      this.$dialog.dialog("option", "height", 500);
+      this.$dialog.dialog("option", "width", 800);
+    }
+    //this.resize();
+    this.first_time = false;
+  }
+
+  FlotGraph.prototype.onDataReceived.call(this, series);
+
+  if (this.graph_title)
+    this.$dialog.dialog('option', 'title', this.graph_title);
+};

--- a/js/ganglia.js
+++ b/js/ganglia.js
@@ -103,6 +103,14 @@ function ganglia_submit(clearonly) {
     document.ganglia_form.submit();
 }
 
+function getTimezone() {
+  var tzValue = "browser";
+  var tz = $("#tz");
+  if (tz[0] && tz.val() === "")
+    tzValue = server_timezone;
+  return tzValue;
+}
+
 /* ----------------------------------------------------------------------------
  Enlarges a graph using Flot
 -----------------------------------------------------------------------------*/
@@ -111,9 +119,13 @@ function inspectGraph(graphArgs) {
   $("#popup-dialog").bind("dialogbeforeclose",
                           function(event, ui) {
                             $("#enlargeTooltip").remove();});
-  $.get('inspect_graph.php',
-        "flot=1&" + graphArgs,
-        function(data) {$('#popup-dialog-content').html(data);});
+  var graph = new InspectGraph(graphArgs,
+                               g_refreshInterval,
+                               getTimezone(),
+                               $("#popup-dialog"));
+  $('#popup-dialog-content').html(graph.getBaseHtml());
+  graph.initialize();
+  graph.start();
 }
 
 /* ----------------------------------------------------------------------------

--- a/templates/default/header.tpl
+++ b/templates/default/header.tpl
@@ -8,7 +8,8 @@
     <script type="text/javascript">
      var time_ranges = {$time_ranges};
      var server_timezone='{$server_timezone}';
-     var g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+     var g_refreshInterval = {$refresh};
+     var g_refresh_timer = setTimeout("refresh()", g_refreshInterval * 1000);
      var tz = jstz.determine();
 
      function refreshHeader() {
@@ -27,31 +28,31 @@
        var selected_tab = $("#selected_tab").val();
        if (selected_tab == "agg") {
          refreshAggregateGraph();
-         g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+         g_refresh_timer = setTimeout("refresh()", g_refreshInterval * 1000);
        } else if (selected_tab == "s") {
          // Dont refresh the serach tab
        } else if (selected_tab == "v") {
          refreshHeader();
          if ($.isFunction(window.refreshView)) {
            refreshView();
-           g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+           g_refresh_timer = setTimeout("refresh()", g_refreshInterval * 1000);
          } else if ($.isFunction(window.refreshDecomposeGraph)) {
            refreshDecomposeGraph();
-           g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+           g_refresh_timer = setTimeout("refresh()", g_refreshInterval * 1000);
          } else
          ganglia_form.submit();
        } else if (selected_tab == "ev") {
          refreshOverlayEvent();
-         g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+         g_refresh_timer = setTimeout("refresh()", g_refreshInterval * 1000);
        } else if (selected_tab == "m") {
          if ($.isFunction(window.refreshClusterView)) {
            refreshHeader();
            refreshClusterView();
-           g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+           g_refresh_timer = setTimeout("refresh()", g_refreshInterval * 1000);
          } else if ($.isFunction(window.refreshHostView)) {
            refreshHeader();
            refreshHostView();
-           g_refresh_timer = setTimeout("refresh()", {$refresh} * 1000);
+           g_refresh_timer = setTimeout("refresh()", g_refreshInterval * 1000);
          } else
          ganglia_form.submit();
        } else
@@ -320,12 +321,46 @@
           </div>
           <div>
             <div style="float:left;padding:5px 0 0 5px;">{$range_menu}</div>
-            <div style="float:left;padding:5px 0 0 5px;"
-                 id="custom_range_menu">{$custom_time}</div>
-            <div style="float:left;padding:5px 0 0 5px;" id="timezone">
-              {$timezone_picker}
+            {if $context == "meta" || $context == "cluster" || $context == "cluster-summary" || $context == "host" || $context == "views" || $context == "decompose_graph" || $context == "compare_hosts"}
+              {assign "Feb 27 2007 00:00, 2/27/2007, 27.2.2007, now -1 week, -2 days, start + 1 hour, etc." examples}
+              <div style="float:left;padding:5px 0 0 5px;"
+                   id="custom_range_menu">
+                <span class="nobr">or&nbsp;from&nbsp;
+                  <input type="text"
+                         title="{$examples}"
+                         name="cs"
+                         id="datepicker-cs"
+                         size="17"
+                         {if isset($cs)} value="{$cs}"{/if}>
+                  &nbsp;to&nbsp;
+                  <input type="text"
+                         title="{$examples}"
+                         name="ce"
+                         id="datepicker-ce"
+                         size="17"
+                         {if isset($ce)} value="{$ce}"{/if}>
+                  &nbsp;
+                  <input type="submit" value="Go">
+                  <input type="button" value="Clear" onclick="ganglia_submit(1)">
+                </span>
+              </div>
+              <div style="float:left;padding:5px 0 0 5px;" id="timezone">Timezone:&nbsp;
+                <select id="timezone-picker" style="width:100px;">
+                  <option value="browser">Browser</option>
+                  <option value="server">Server</option>
+                </select>
+              </div>
+            {/if}
+            <div style="float:right;padding:5px 0 0 5px;">
+              {if $context == "views" || $context == "decompose_graph" || $context == "host"}
+                <input title="Hide/Show Events"
+                       type="checkbox"
+                       id="show_all_events"
+                       onclick="showAllEvents(this.checked)"/>
+                <label for="show_all_events">Hide/Show Events</label>
+              {/if}
+              &nbsp;&nbsp;{$alt_view}
             </div>
-            <div style="float:right;padding:5px 0 0 5px;">{$additional_buttons}&nbsp;&nbsp;{$alt_view}</div>
             <div style="clear:both;"></div>
           </div>
           {if $context != "cluster" && $context != "cluster-summary"}

--- a/templates/default/host_view.tpl
+++ b/templates/default/host_view.tpl
@@ -130,8 +130,9 @@ function refreshHostView() {
 
   $("#optional_graphs img").each(function (index) {
     var src = $(this).attr("src");
-    if ((src.indexOf("graph.php") == 0) ||
-        (src.indexOf("./graph.php") == 0)) {
+    if ((src.indexOf("graph.php") == 0 ||
+         src.indexOf("./graph.php") == 0) &&
+        $(this).visible(true, true)) {
       var d = new Date();
       $(this).attr("src", jQuery.param.querystring(src, "&_=" + d.getTime()));
     }
@@ -139,8 +140,9 @@ function refreshHostView() {
 
   $("#metrics img").each(function (index) {
     var src = $(this).attr("src");
-    if ((src.indexOf("graph.php") == 0)  ||
-        (src.indexOf("./graph.php") == 0)) {
+    if ((src.indexOf("graph.php") == 0  ||
+        src.indexOf("./graph.php") == 0) &&
+        $(this).visible(true, true)) {
       var d = new Date();
       $(this).attr("src", jQuery.param.querystring(src, "&_=" + d.getTime()));
     }

--- a/templates/default/scripts.tpl
+++ b/templates/default/scripts.tpl
@@ -25,7 +25,6 @@
 <script type="text/javascript" src="js/jquery.ba-bbq.min.js"></script>
 <script type="text/javascript" src="js/combobox.js"></script>
 <script type="text/javascript" src="{$conf['jquery_scrollTo_js_path']}"></script>
-<script type="text/javascript" src="js/jquery.buttonsetv.js"></script>
 <script type="text/javascript" src="{$conf['jstree_js_path']}"></script>
 <script type="text/javascript" src="js/jquery.qtip.min.js"></script>
 <script type="text/javascript" src="{$conf['chosen_js_path']}"></script>
@@ -42,3 +41,5 @@
 <script type="text/javascript" src="js/jquery.flot.ganglia-time.js"></script>
 <script type="text/javascript" src="js/jquery.flot.events.js"></script>
 <script type="text/javascript" src="js/jquery.flot.dashes.js"></script>
+<script type="text/javascript" src="js/flot_graph.js"></script>
+<script type="text/javascript" src="{$conf['jquery_visible_js_path']}"></script>

--- a/templates/default/view_content.tpl
+++ b/templates/default/view_content.tpl
@@ -1,38 +1,84 @@
+{if isset($flot_graph)}
+  <script type="text/javascript">
+   $(function() {
+     var viewGraphs = [];
+     {foreach $view_items view_item}
+     viewGraphs.push("{$view_item.url_args}");
+     {/foreach}
+     var tz = getTimezone();
+     for (var i = 0; i < viewGraphs.length; i++) {
+       var viewGraph = viewGraphs[i];
+       console.log(viewGraph);
+       var flotGraph = new FlotGraph(viewGraph,
+                                     g_refreshInterval,
+                                     tz);
+       var $viewItem = $("#flot_view_item_" + i);
+       $viewItem.html(flotGraph.getBaseHtml());
+       flotGraph.initialize();
+       flotGraph.start();
+     }
+   });
+  </script>
+{/if}
 <div id="views-content">
   <div id=view_graphs>
     <script type="text/javascript">viewCommonYaxis={if $common_y_axis}true{else}false{/if};yAxisUpperLimit=null;yAxisLowerLimit=null;</script>
     {if isset($number_of_view_items)}
-    {if $number_of_view_items == 0 }
-    <div class="ui-widget">
-      <div class="ui-state-default ui-corner-all" style="padding: 0 .7em;"> 
-        <p><span class="ui-icon ui-icon-alert" style="float: left; margin-right: .3em;"></span>
-          No graphs defined for this view. Please add some
-      </div>
-    </div>
-    {else}
-      {$i = 0}
-      {foreach $view_items view_item}
-      {$graphId = cat($GRAPH_BASE_ID "view_" $i)}
-      {$showEventsId = cat($SHOW_EVENTS_BASE_ID "view_" $i)}
-      <div class="img_view">
-        <button title="Export to CSV" class="cupid-green" onClick="javascript:location.href='graph.php?{$view_item.url_args}&amp;csv=1';return false;">CSV</button>
-        <button title="Export to JSON" class="cupid-green" onClick="javascript:location.href='graph.php?{$view_item.url_args}&amp;json=1';return false;">JSON</button>
-      {if $view_item['canBeDecomposed'] == 1}
-        <button title="Decompose graph" class="shiny-blue" onClick="javascript:location.href='?{$view_item.url_args}&amp;dg=1&amp;tab=v';return false;">Decompose</button>
+      {if $number_of_view_items == 0}
+        <div class="ui-widget">
+          <div class="ui-state-default ui-corner-all" style="padding: 0 .7em;">
+            <p><span class="ui-icon ui-icon-alert"
+                     style="float: left; margin-right: .3em;"></span>
+              No graphs defined for this view. Please add some
+          </div>
+        </div>
+      {else}
+        {$i = 0}
+        {foreach $view_items view_item}
+          {$graphId = cat($GRAPH_BASE_ID "view_" $i)}
+          {$showEventsId = cat($SHOW_EVENTS_BASE_ID "view_" $i)}
+          <div class="img_view">
+            <button title="Export to CSV"
+                    class="cupid-green"
+                    onClick="javascript:location.href='graph.php?{$view_item.url_args}&amp;csv=1';return false;">CSV</button>
+            <button title="Export to JSON"
+                    class="cupid-green"
+                    onClick="javascript:location.href='graph.php?{$view_item.url_args}&amp;json=1';return false;">JSON</button>
+            {if $view_item['canBeDecomposed'] == 1}
+              <button title="Decompose graph"
+                      class="shiny-blue"
+                      onClick="javascript:location.href='?{$view_item.url_args}&amp;dg=1&amp;tab=v';return false;">Decompose</button>
+            {/if}
+            <button title="Inspect Graph"
+                    onClick="inspectGraph('{$view_item.url_args}'); return false;" class="shiny-blue">Inspect</button>
+            <input type="checkbox"
+                   id="{$showEventsId}"
+                   onclick="showEvents('{$graphId}', this.checked)"/>
+            <label title="Hide/Show Events"
+                   class="show_event_text"
+                   for="{$showEventsId}">Hide/Show Events</label>
+            <br />
+            {if isset($flot_graph)}
+              <div id="flot_view_item_{$i}"
+                   style="height:280px;width:460px;"
+                   class="flotgraph2 img_view"></div>
+            {elseif $graph_engine == "flot"}
+              <div id="placeholder_{$view_item.url_args}"
+                   class="flotgraph2 img_view"></div>
+              <div id="placeholder_{$view_item.url_args}_legend"
+                   class="flotlegend"></div>
+            {else}
+              <a href="graph_all_periods.php?{$view_item.url_args}">
+                <img id="{$graphId}"
+                     class="noborder {$additional_host_img_css_classes}"
+                     style="margin-top:5px;"
+                     src="graph.php?{$view_item.url_args}" />
+              </a>
+            {/if}
+          </div>
+          {math "$i + 1" assign=i}
+        {/foreach}
       {/if}
-        <button title="Inspect Graph" onClick="inspectGraph('{$view_item.url_args}'); return false;" class="shiny-blue">Inspect</button>
-        <input type="checkbox" id="{$showEventsId}" onclick="showEvents('{$graphId}', this.checked)"/><label title="Hide/Show Events" class="show_event_text" for="{$showEventsId}">Hide/Show Events</label>
-        <br />
-{if $graph_engine == "flot"}
-<div id="placeholder_{$view_item.url_args}" class="flotgraph2 img_view"></div>
-<div id="placeholder_{$view_item.url_args}_legend" class="flotlegend"></div>
-{else}
-<a href="graph_all_periods.php?{$view_item.url_args}"><img id="{$graphId}" class="noborder {$additional_host_img_css_classes}" style="margin-top:5px;" src="graph.php?{$view_item.url_args}" /></a>
-{/if}
-      </div>
-      {math "$i + 1" assign=i}
-      {/foreach}
-    {/if}
     {/if}
   </div>
 </div>

--- a/view_content.php
+++ b/view_content.php
@@ -12,8 +12,8 @@ $view_name = NULL;
 if (isset($_GET['vn']) && !is_proper_view_name($_GET['vn'])) {
 ?>
 <div class="ui-widget">
-  <div class="ui-state-default ui-corner-all" styledefault="padding: 0 .7em;"> 
-    <p><span class="ui-icon ui-icon-alert" style="float: left; margin-right: .3em;"></span> 
+  <div class="ui-state-default ui-corner-all" styledefault="padding: 0 .7em;">
+    <p><span class="ui-icon ui-icon-alert" style="float: left; margin-right: .3em;"></span>
     View names valid characters are 0-9, a-z, A-Z, -, _ and space. View has not been created.</p>
   </div>
 </div>
@@ -31,14 +31,14 @@ $data = new Dwoo_Data();
 
 $size = isset($clustergraphsize) ? $clustergraphsize : 'default';
 // set to 'default' to preserve old behavior
-if ($size == 'medium') 
+if ($size == 'medium')
   $size = 'default';
 
 $additional_host_img_css_classes = "";
 if (isset($conf['zoom_support']) && $conf['zoom_support'] === true)
   $additional_host_img_css_classes = "host_${size}_zoomable";
 
-$data->assign("additional_host_img_css_classes", 
+$data->assign("additional_host_img_css_classes",
               $additional_host_img_css_classes);
 
 $view_items = NULL;
@@ -61,7 +61,8 @@ if (isset($view_items)) {
 
 $data->assign('GRAPH_BASE_ID', $GRAPH_BASE_ID);
 $data->assign('SHOW_EVENTS_BASE_ID', $SHOW_EVENTS_BASE_ID);
-
+$data->assign('graph_engine', $conf['graph_engine']);
+$data->assign('flot_graph', isset($conf['flot_graph']) ? true : null);
 $dwoo->output($tpl, $data);
 
 ?>

--- a/views_view.php
+++ b/views_view.php
@@ -432,7 +432,8 @@ if (isset($view_items)) {
 
 $data->assign('GRAPH_BASE_ID', $GRAPH_BASE_ID);
 $data->assign('SHOW_EVENTS_BASE_ID', $SHOW_EVENTS_BASE_ID);
-
+$data->assign('graph_engine', $conf['graph_engine']);
+$data->assign('flot_graph', isset($conf['flot_graph']) ? true : null);
 $dwoo->output($tpl, $data);
 
 ?>


### PR DESCRIPTION
- Converted inspect_graph.php into js/flot_graph.js which contains two classes FlotGraph and InspectGraph. InspectGraph is used to implement the current inspection functionality, and FlotGraph provides a reusable graph based on Flot that may be used for graph-engine = flot.
- Added a Clear button to the Inspect graph Line/Stack/Clear toolbar. This allows for rrdtool graphs that are a combination of stacks and lines to be rendered correctly. The cleared state is active by default.
- Improve performance of the host view by only refreshing graphs visible in the browser viewport. It is planned to make similar changes to other views.
- Fixed an issue where series in metric graphs were not labeled using the metric metric name which resulted in them not being correctly rendered when exported to views.