### PR TITLE
Show data for down nodes

### DIFF
--- a/conf_default.php.in
+++ b/conf_default.php.in
@@ -442,6 +442,11 @@ $conf['display_views_using_tree'] = false;
 # those code paths to save time during XML parsing.
 $conf['strip_extra'] = true;
 
+# By default, if a host goes down, the graphs and information available
+# under the host view are not shown. Setting this variable to true will show
+# the information even if the host is down.
+$conf['show_host_data_if_down'] = true;
+
 # By default we'll just download Jquery, Cubism and D3 required libraries from a CDN that offers
 # that for free. If that is undesirable you can override this in conf.php by putting
 # downloading the asset and putting relative path or absolute paths to it e.g.

--- a/host_view.php
+++ b/host_view.php
@@ -268,8 +268,8 @@ getHostOverViewData($hostname,
                     $always_constant, 
                     $data);
 
-# No reason to go on if this node is down.
-if ($hosts_down) {
+# When this node is down, only show data when show_host_data_if_down is True
+if ($hosts_down && !$conf['show_host_data_if_down']) {
   $dwoo->output($tpl, $data);
   return;
 }


### PR DESCRIPTION
This is essentially a copy of pull request #254 by RyanFolsom. Since he hasn't responded for over a year I created my own clone and applied his fix (please let me know if this is not the usual procedure!):

From #254:
> The Problem
In the Web UI if a host goes down, many of the metrics become unavailable. These metrics can be extremely valuable in determining what went wrong. In some cases, these hosts may never come back (such as autoscaling groups through Amazon).

> The Change
Added a variable in the configuration file, $conf['show_host_data_if_down']. When false (default), the additional metrics do not render, and the behavior as it is today does not change. If set to true, the graphs and metrics will render under the host_view page, even if the host is down.

Especially when a node went down I'd like to have a look at Ganglia data to analyse what possibly went wrong. The default value of _show_host_data_if_down_ may well be set to True.

