### PR TITLE
Fix incorrect conf_dir variable

### DIFF
--- a/host_view.php
+++ b/host_view.php
@@ -79,10 +79,10 @@ function getOptionalReports($hostname,
       json_decode(file_get_contents($conf_dir . "/default.json"),
 		  TRUE));
   }
-  if ( is_file($conf['conf_dir'] . "/default_host.json") ) {
+  if ( is_file($conf_dir . "/default_host.json") ) {
     $default_reports = array_merge(
       $default_reports,
-      json_decode(file_get_contents($conf['conf_dir'] . "/default_host.json"),
+      json_decode(file_get_contents($conf_dir . "/default_host.json"),
 		  TRUE));
   }
 


### PR DESCRIPTION
In 52f72b961b80e6e47a18b34af8601aeacaf3c534 getOptionalReports() was refactored not to use global $conf_dir variable but instead pass needed variables as parameters. This broke another change, 0888f0195507a5557a8a5656be586505a38a983a, thas was merged the same day.