### PR TITLE
Cope with mem RRD missing cached/slab/buffers

### DIFF
--- a/graph.d/mem_report.php
+++ b/graph.d/mem_report.php
@@ -55,9 +55,9 @@ function graph_mem_report ( &$rrdtool_graph ) {
            ."CDEF:'bmem_shared'=mem_shared,1024,* ";
     }
 
-    if (file_exists("$rrd_dir/mem_slab.rrd")) {
+    if (file_exists("$rrd_dir/mem_sreclaimable.rrd")) {
        $bmem_used_cdef .= ",'bmem_slab',UN,0,'bmem_slab',IF,-";
-       $bmem_slab_defs = "DEF:'mem_slab'='${rrd_dir}/mem_slab.rrd':'sum':AVERAGE "
+       $bmem_slab_defs = "DEF:'mem_slab'='${rrd_dir}/mem_sreclaimable.rrd':'sum':AVERAGE "
            ."CDEF:'bmem_slab'=mem_slab,1024,* ";
     }
 
@@ -121,7 +121,7 @@ function graph_mem_report ( &$rrdtool_graph ) {
                 . "GPRINT:'cached_max':'${space1}Max\:%6.1lf%s\\l' ";
     }
 
-    if (file_exists("$rrd_dir/mem_slab.rrd")) {
+    if (file_exists("$rrd_dir/mem_sreclaimable.rrd")) {
         $series .= "STACK:'bmem_slab'#${conf['mem_slab_color']}:'Slab${rmspace}' ";
 
         if ( $conf['graphreport_stats'] ) {

--- a/graph.d/mem_report.php
+++ b/graph.d/mem_report.php
@@ -50,19 +50,19 @@ function graph_mem_report ( &$rrdtool_graph ) {
     $bmem_used_cdef = "CDEF:'bmem_used'='bmem_total','bmem_free',-,'bmem_cached',-";
 
     if (file_exists("$rrd_dir/mem_shared.rrd")) {
-       $bmem_used_cdef .= ",'bmem_shared',-";
+       $bmem_used_cdef .= ",'bmem_shared',UN,0,'bmem_shared',IF,-";
        $bmem_shared_defs = "DEF:'mem_shared'='${rrd_dir}/mem_shared.rrd':'sum':AVERAGE "
            ."CDEF:'bmem_shared'=mem_shared,1024,* ";
     }
 
     if (file_exists("$rrd_dir/mem_slab.rrd")) {
-       $bmem_used_cdef .= ",'bmem_slab',-";
+       $bmem_used_cdef .= ",'bmem_slab',UN,0,'bmem_slab',IF,-";
        $bmem_slab_defs = "DEF:'mem_slab'='${rrd_dir}/mem_slab.rrd':'sum':AVERAGE "
            ."CDEF:'bmem_slab'=mem_slab,1024,* ";
     }
 
     if (file_exists("$rrd_dir/mem_buffers.rrd")) {
-       $bmem_used_cdef .= ",'bmem_buffers',-";
+       $bmem_used_cdef .= ",'bmem_buffers',UN,0,'bmem_buffers',IF,-";
        $bmem_buffers_defs = "DEF:'mem_buffers'='${rrd_dir}/mem_buffers.rrd':'sum':AVERAGE "
            ."CDEF:'bmem_buffers'=mem_buffers,1024,* ";
     }


### PR DESCRIPTION
When introducing the new values for "slab",
there is period when old values are missing...

Make sure to count those as zero properly,
so that the total amount of memory lines up

----
Sorry @vvuksan - same as in 6d6195f571402413d5df747e37330b2cba6077f4