### PR TITLE
Add the available memory to the graph, if present

### DIFF
--- a/conf_default.php.in
+++ b/conf_default.php.in
@@ -135,6 +135,7 @@ $conf['cpu_gnice_color'] = "fff261";
 # Colors for the MEMORY report graph
 #
 $conf['mem_used_color'] = "5555cc";
+$conf['mem_available_color'] = "2030F4";
 $conf['mem_shared_color'] = "0000aa";
 $conf['mem_cached_color'] = "33cc33";
 $conf['mem_slab_color'] = "66e533";


### PR DESCRIPTION
Newer Linux kernels (3.14 and some backports) have a MemAvailable field
that provides a more accurate estimate of memory available to userspace.

Show this metric (if present), since not all of Cached and Slab can be
used or reclaimed - which makes our (guess of) "Use" to be inaccurate...

Needs PR https://github.com/ganglia/monitor-core/pull/300 (for the metric)