### PR TITLE
Add default arguments so decompose works on php7.1

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1121,8 +1121,8 @@ function build_aggregate_graph_config ($graph_type,
                                        $line_width,
                                        $hreg,
                                        $mreg,
-                                       $glegend,
-                                       $exclude_host_from_legend_label,
+                                       $glegend = NULL,
+                                       $exclude_host_from_legend_label = false,
                                        $sortit = true) {
 
   global $conf, $index_array, $hosts, $grid, $clusters, $debug, $metrics;


### PR DESCRIPTION
PHP 7.1 introduces a fatal error when you call a method with not enough arguments (https://www.php.net/manual/en/migration71.incompatible.php)

Sample error you'd see:
```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function build_aggregate_graph_config(), 4 passed in /home/ganglia-webfrontend/decompose_graph.php on line 40 and exactly 6 expected in /home/ganglia-webfrontend/functions.php:1156
```

Based off decompose's usage, these arguments were always intended to be optional (especially since we run `isset()` later), thus I recommend making them optional.