### PR TITLE
Fix "Uncaught DivisionByZeroError: Modulo by zero"

### DIFF
--- a/templates/default/cluster_host_metric_graphs.tpl
+++ b/templates/default/cluster_host_metric_graphs.tpl
@@ -42,7 +42,7 @@
       {/foreach}
     {/if}
   {/if}
-  {if $index % $hostcols == 0}
+  {if $index % max(1, $hostcols) == 0}
     </tr><tr>
   {/if}
   {math "$index + 1" assign="index"}


### PR DESCRIPTION
Starting from PHP7 selecting 0 columns (metric + report) throws exception after printing first host.