### PR TITLE
(re)add single quotes to title

### DIFF
--- a/stacked.php
+++ b/stacked.php
@@ -37,7 +37,7 @@ $command .= " --height 300";
 
 $title .= isset($_GET['title']) ?
   $_GET['title'] : "$clustername aggregated $metricname last $range";
-$command .= " --title " . sanitize($title);
+$command .= " --title '" . sanitize($title) . "'";
 
 if (isset($_GET['x']))
   $command .= " --upper-limit " . sanitize($_GET[x]);


### PR DESCRIPTION
This re-adds single quotes to the title as these are stripped by the `sanitize` function and cause rrdtool to fail when generating the stacked graph. This fixed the issue of not showing the stacked graphs on the main page for me. Maybe this has to be considered elsewhere as well?