### PR TITLE
Remove error_log() call which is trace from cluster_view.php

### DIFF
--- a/cluster_view.php
+++ b/cluster_view.php
@@ -740,7 +740,6 @@ if (isset($conf['heatmaps_enabled']) and
 $tpl_data->assign("conf", $conf);
 $tpl_data->assign("showhosts", $user['showhosts']);
 
-error_log("reports = " . print_r($reports, TRUE));
 $tpl_data->assign("reports_metricname",
                   isset($reports[$user['metricname']]) &&
                   $reports[$user['metricname']]);


### PR DESCRIPTION
When displaying a cluster view I get this message in apache's error.log:

reports = Array\n(\n    [load_report] => load_one\n    [cpu_report] => 1\n
    [mem_report] => 1\n    [network_report] => 1\n    [packet_report] => 1\n)\n

For me it looks like a trace - lets remove it.