### PR TITLE
Fix php8 error in function.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -729,7 +729,7 @@ function get_view_graph_elements($view) {
   case "standard":
     // Does view have any items/graphs defined
     if ( count($view['items']) == 0 ) {
-      continue;
+      break;
       // print "No graphs defined for this view. Please add some";
     } else {
       // Loop through graph items


### PR DESCRIPTION
I got the message:
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?
 in /usr/share/ganglia-webfrontend/functions.php on line 732

This messages is likely new with php7.3. Will be an error with PHP8.
For details see https://wiki.php.net/rfc/continue_on_switch_deprecation

This in one small step to get ready for php8. See https://github.com/ganglia/ganglia-web/issues/361