### PR TITLE
Web-Interface still displays version 3.7.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ PHPCBF = phpcbf
 ##########################################################
 
 # Gweb version
-GWEB_VERSION = 3.7.4
+GWEB_VERSION = 3.7.5
 
 DIST_NAME = ganglia-web
 DIST_DIR = $(DIST_NAME)-$(GWEB_VERSION)


### PR DESCRIPTION
Current release is 3.7.5, but the web interface displays 3.7.4.
Is there a "release checklist"? This has been forgotten in the past...