### PR TITLE
Update error handler for php 7.2

### DIFF
--- a/lib/common_api.php
+++ b/lib/common_api.php
@@ -15,8 +15,7 @@ function api_return_ok ( $message ) {
 
 // Handle PHP error
 set_error_handler("ganglia_api_error_handler");
-function ganglia_api_error_handler ($no, $str, $file, $line, $context) {
-  $context; // PHPCS
+function ganglia_api_error_handler ($no, $str, $file, $line) {
   switch ($no) {
     case E_ERROR:
     case E_CORE_ERROR:


### PR DESCRIPTION
According to the php documentation the "context" parameter to the
error handler has been deprecated:
https://www.php.net/manual/en/function.set-error-handler.php

Let's move on and get ready for a newer php version (debian bullseye has 7.4).

This in one small step to get ready for php8. See https://github.com/ganglia/ganglia-web/issues/361