### PR TITLE
Replace str_split with explode

### DIFF
--- a/api/host.php
+++ b/api/host.php
@@ -54,7 +54,7 @@ switch ( $_GET['action'] ) {
       if (strpos($v, ";") !== false) {
         continue; // skip weird invalid directories
       }
-      list( $_cluster, $_host ) = str_split( '/', $v );
+      list( $_cluster, $_host ) = explode( '/', $v );
       $hosts[$_host]['clusters'][] = $_cluster;
       $clusters[$_cluster][] = $_host;
     }


### PR DESCRIPTION
In c5e5831d23c6db0b04a868578680b32cb03ee952 an attempt was made to replace the deprecated `split` function for PHP 7.0. However, `str_split` was not the correct replacement for the task. `explode` is the function that needs to be used here.