### PR TITLE
Fix json reports in cluster context using host metrics

### DIFF
--- a/graph.php
+++ b/graph.php
@@ -887,7 +887,7 @@ function rrdgraph_cmd_build($rrdtool_graph,
 
 	// We need to add hostname and clustername if it's not specified
 	foreach (array_keys($graph_config['series']) as $series_id) {
-	  if (! isset($graph_config['series'][$index]['hostname'])) {
+	  if (! isset($graph_config['series'][$series_id]['hostname'])) {
 	    $graph_config['series'][$series_id]['hostname'] = $raw_host;
 	    if (isset($grid))
 	      $graph_config['series'][$series_id]['clustername'] = $grid;


### PR DESCRIPTION
We have pool CPU reports for Power systems in json format with metrics like these:
"series" : [
      { "hostname": "host1", "clustername": "C1", "metric": "cpu_used", "color": "00ff00", "label": "host1", "type": "stack" },
      { "hostname": "host2", "clustername": "C1", "metric": "cpu_used", "color": "0000ff", "label": "host2", "type": "stack" },
...
      { "hostname": "host1", "clustername": "C1", "metric": "cpu_in_pool", "color": "000000", "label": "CPU in Pool", "line_width": "2", "type": "line" }
]

Expected outcome is that each area represents the CPU usage of an LPAR.
The reports displayed the same CPU used values for all LPARs instead and no
correlation to the single LPAR.

When calling graph.php with the option "&debug=3" we saw in the rrdtool command:
https://ganglia.example.org/ganglia/graph.php?r=hour&z=xlarge&c=C1&m=cluster_C1_pool_2_report&s=by+name&mc=2&g=cluster_C1_pool_2_report&debug=3
...
DEF:'a0'='/var/lib/ganglia/rrds/C1/__SummaryInfo__/cpu_used.rrd':'sum':AVERAGE
DEF:'a1'='/var/lib/ganglia/rrds/C1/__SummaryInfo__/cpu_used.rrd':'sum':AVERAGE
...
So instead of using the values for the single LPAR we used the Cluster summary.
Reason for that is an incomplete refactoring in
https://github.com/ganglia/ganglia-web/commit/7d50fddc318660b0e1973963f422a2c4c5eb3c3c
In that commit the loop variable has been renamed from "index" to "series_id", but one reference has been missed.